### PR TITLE
Update hue.py from the latest 0.60.1

### DIFF
--- a/custom_components/hue.py
+++ b/custom_components/hue.py
@@ -161,6 +161,8 @@ class HueBridge(object):
         self.allow_hue_groups = allow_hue_groups
 
         self.bridge = None
+        self.lights = {}
+        self.lightgroups = {}
 
         self.configured = False
         self.config_request_id = None


### PR DESCRIPTION
Hopefully this will update the _custom_component/hue.py_ to the latest version of _hue.py_ from home assistant 0.60.1, along with the changes necessary to allow the sensors to still work