### PR TITLE
Make key unique

### DIFF
--- a/custom_components/sensor/hue.py
+++ b/custom_components/sensor/hue.py
@@ -27,7 +27,7 @@ def parse_hue_api_response(response):
         sensor = response[key]
         modelid = sensor['modelid'][0:3]
         if modelid in ['RWL', 'SML', 'ZGP']:
-            _key = modelid + '_' + sensor['uniqueid'].split(':')[-1][0:5]
+            _key = modelid + '_' + sensor['uniqueid'][:-5]
 
             if modelid == 'RWL':
                 data_dict[_key] = parse_rwl(sensor)

--- a/debugging_issues/Missing_sensor/Debug pastebin error Hue sevenofnine.ipynb
+++ b/debugging_issues/Missing_sensor/Debug pastebin error Hue sevenofnine.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -182,7 +182,7 @@
        "  'temperature': 22.54}}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
        " 'RWL_06-02']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,11 +241,291 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Issue fix\n",
+    "As proposed by @sevenofnine-jni all characters of the unique_id can be used except for the final four where 0400 = light, 0402 = temp and 0406 is motion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uniqueid = \"00:17:88:01:02:12:dc:d0-02-0402\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key = uniqueid[:-5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'00:17:88:01:02:12:dc:d0-02'"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets update the parsing function and try that"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_hue_api_response(response):\n",
+    "    \"\"\"Take in the Hue API json response.\"\"\"\n",
+    "    data_dict = {}    # The list of sensors, referenced by their hue_id.\n",
+    "\n",
+    "    # Loop over all keys (1,2 etc) to identify sensors and get data.\n",
+    "    for key in response.keys():\n",
+    "        sensor = response[key]\n",
+    "        modelid = sensor['modelid'][0:3]\n",
+    "        if modelid in ['RWL', 'SML', 'ZGP']:\n",
+    "            _key = modelid + '_' + sensor['uniqueid'][:-5]  # Updated key\n",
+    "\n",
+    "            if modelid == 'RWL':\n",
+    "                data_dict[_key] = hs.parse_rwl(sensor)\n",
+    "            elif modelid == 'ZGP':\n",
+    "                data_dict[_key] = hs.parse_zgp(sensor)\n",
+    "            elif modelid == 'SML':\n",
+    "                if _key not in data_dict.keys():\n",
+    "                    data_dict[_key] = hs.parse_sml(sensor)\n",
+    "                else:\n",
+    "                    data_dict[_key].update(hs.parse_sml(sensor))\n",
+    "\n",
+    "        elif sensor['modelid'] == 'HA_GEOFENCE':\n",
+    "            data_dict['Geofence'] = hs.parse_geofence(sensor)\n",
+    "    return data_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_new = parse_hue_api_response(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'RWL_00:17:88:01:02:0e:9d:9e-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-25', '18:58:53'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'Vardagsrummet dimmer switch 1',\n",
+       "  'state': '4_click'},\n",
+       " 'RWL_00:17:88:01:02:0e:9d:b8-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-28', '13:25:26'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'Baksidan dimmer switch',\n",
+       "  'state': '4_click'},\n",
+       " 'RWL_00:17:88:01:02:0e:9e:c5-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-25', '19:00:03'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'Framsidan dimmer switch',\n",
+       "  'state': '1_click'},\n",
+       " 'RWL_00:17:88:01:02:0f:f3:6c-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-25', '18:59:01'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'Vardagsrummet dimmer switch 2',\n",
+       "  'state': '1_click'},\n",
+       " 'RWL_00:17:88:01:02:0f:fe:86-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-28', '13:25:25'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'köket dimmer switch',\n",
+       "  'state': '4_click'},\n",
+       " 'RWL_00:17:88:01:02:0f:fe:b9-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-28', '13:25:25'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'Teverummet dimmer switch',\n",
+       "  'state': '4_click'},\n",
+       " 'RWL_00:17:88:01:02:c1:13:06-02': {'battery': 100,\n",
+       "  'last_updated': ['2018-01-28', '11:28:35'],\n",
+       "  'model': 'RWL',\n",
+       "  'name': 'badrummet dimmer switch',\n",
+       "  'state': '4_click'},\n",
+       " 'SML_00:17:88:01:02:10:7d:1e-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:47:29'],\n",
+       "  'light_level': 9399,\n",
+       "  'lux': 8.71,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'teverummet motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 19.86},\n",
+       " 'SML_00:17:88:01:02:12:37:73-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:41:06'],\n",
+       "  'light_level': 3645,\n",
+       "  'lux': 2.31,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'köket motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 20.54},\n",
+       " 'SML_00:17:88:01:02:13:96:9e-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '16:58:25'],\n",
+       "  'light_level': 0,\n",
+       "  'lux': 1.0,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'uppfarten motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 20.3},\n",
+       " 'SML_00:17:88:01:02:13:a1:2e-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '17:23:11'],\n",
+       "  'light_level': 0,\n",
+       "  'lux': 1.0,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'hobbyrummet motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 20.23},\n",
+       " 'SML_00:17:88:01:02:13:bb:2a-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:40:56'],\n",
+       "  'light_level': 5047,\n",
+       "  'lux': 3.2,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'vardagsrummet motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 20.5},\n",
+       " 'SML_00:17:88:01:02:13:db:2e-02': {'battery': 100,\n",
+       "  'dark': False,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:40:39'],\n",
+       "  'light_level': 19598,\n",
+       "  'lux': 91.14,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'bathroom downstairs motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 24.11},\n",
+       " 'SML_00:17:88:01:02:13:db:4a-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:40:42'],\n",
+       "  'light_level': 11915,\n",
+       "  'lux': 15.54,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'Hallen motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 19.72},\n",
+       " 'SML_00:17:88:01:02:13:e6:fa-02': {'battery': 100,\n",
+       "  'dark': True,\n",
+       "  'daylight': False,\n",
+       "  'last_updated': ['2018-01-28', '19:47:42'],\n",
+       "  'light_level': 9768,\n",
+       "  'lux': 9.48,\n",
+       "  'model': 'SML',\n",
+       "  'name': 'Entrance motion sensor',\n",
+       "  'state': 'off',\n",
+       "  'temperature': 22.54}}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['RWL_00:17:88:01:02:0e:9d:b8-02',\n",
+       " 'RWL_00:17:88:01:02:0e:9e:c5-02',\n",
+       " 'RWL_00:17:88:01:02:0f:f3:6c-02',\n",
+       " 'RWL_00:17:88:01:02:0e:9d:9e-02',\n",
+       " 'RWL_00:17:88:01:02:0f:fe:b9-02',\n",
+       " 'SML_00:17:88:01:02:10:7d:1e-02',\n",
+       " 'SML_00:17:88:01:02:12:37:73-02',\n",
+       " 'SML_00:17:88:01:02:13:e6:fa-02',\n",
+       " 'SML_00:17:88:01:02:13:db:4a-02',\n",
+       " 'SML_00:17:88:01:02:13:a1:2e-02',\n",
+       " 'SML_00:17:88:01:02:13:96:9e-02',\n",
+       " 'SML_00:17:88:01:02:13:bb:2a-02',\n",
+       " 'SML_00:17:88:01:02:13:db:2e-02',\n",
+       " 'RWL_00:17:88:01:02:0f:fe:86-02',\n",
+       " 'RWL_00:17:88:01:02:c1:13:06-02']"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keys = list(data_new.keys())\n",
+    "print(len(keys))\n",
+    "keys"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "7 remotes and 8 motion sensors."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "Error fixed."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Issue
https://github.com/robmarkcole/Hue-sensors-HASS/issues/40#issuecomment-3
61171662 identified that the previous key used to group motion sensor
child sensors was not unique. This commit simplifies the key and
guarantees that it is unique. Note that in the final digits of
unique_id, 0400 = light, 0402 = temp and 0406 is motion.