### PR TITLE
Test to make sure a button has actually been pressed on the dimmer.

### DIFF
--- a/custom_components/sensor/hue.py
+++ b/custom_components/sensor/hue.py
@@ -124,9 +124,11 @@ def parse_rwl(response):
         '3' : "_hold_up"
     }
 
-    press = str(response['state']['buttonevent'])
 
-    button = str(press)[0] + responsecodes[press[-1]]
+    button = ""
+    if response['state']['buttonevent']:
+        press = str(response['state']['buttonevent'])
+        button = str(press)[0] + responsecodes[press[-1]]
 
     data = {'model': 'RWL',
             'name': response['name'],


### PR DESCRIPTION
This adds a check to make sure that a button has been pressed on the dimmer. Otherwise HA returns `null` for `buttonevent` and that made this component very sad indeed.

Fixes #72.

Signed-off-by: Avi Miller <me@dje.li>