### PR TITLE
Add sensitivity attribute

### DIFF
--- a/custom_components/binary_sensor/hue.py
+++ b/custom_components/binary_sensor/hue.py
@@ -36,6 +36,7 @@ ATTRS = {
         "temperature",
         "on",
         "reachable",
+        "sensitivity",
     ],
     "RWL": ["last_updated", "battery", "on", "reachable"],
     "ZGP": ["last_updated"],
@@ -106,6 +107,7 @@ def parse_sml(response):
             "battery": response["config"]["battery"],
             "on": response["config"]["on"],
             "reachable": response["config"]["reachable"],
+            "sensitivity": response["config"]["sensitivity"],
             "last_updated": response["state"]["lastupdated"].split("T"),
         }
     return data

--- a/custom_components/sensor/hue.py
+++ b/custom_components/sensor/hue.py
@@ -35,6 +35,7 @@ ATTRS = {
         "temperature",
         "on",
         "reachable",
+        "sensitivity",
     ],
     "RWL": ["last_updated", "battery", "on", "reachable"],
     "ZGP": ["last_updated"],


### PR DESCRIPTION
I sometimes change the motion sensor sensitivity level from automations, and find it helpful to be able to observe the current value on the binary_sensor.