### PR TITLE
Catch event 0 from FOH switch

### DIFF
--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -127,7 +127,7 @@ def parse_foh(response):
     }
     
     press = response['state']['buttonevent']
-    if press is None:
+    if press == None or press == 0 :
         button = 'No data'
     else:
         button =FOH_BUTTONS[press]


### PR DESCRIPTION
The FOH switch can return a series of events. Currently '0' is not catched. This value '0' is returned by the Hue API upon initialization of a new switch.