### PR TITLE
Fix: Error while setting up platform huesensor - KeyError: 'hue'

### DIFF
--- a/custom_components/huesensor/binary_sensor.py
+++ b/custom_components/huesensor/binary_sensor.py
@@ -121,11 +121,13 @@ def get_bridges(hass):
     from homeassistant.components import hue
     from homeassistant.components.hue.bridge import HueBridge
 
-    return [
-        entry
-        for entry in hass.data[hue.DOMAIN].values()
-        if isinstance(entry, HueBridge) and entry.api
-    ]
+    if(hue.DOMAIN in hass.data):
+        return [
+            entry
+            for entry in hass.data[hue.DOMAIN].values()
+            if isinstance(entry, HueBridge) and entry.api
+        ]
+    return False
 
 
 async def update_api(api):

--- a/custom_components/huesensor/binary_sensor.py
+++ b/custom_components/huesensor/binary_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 DEPENDENCIES = ["hue"]
 
-__version__ = "1.4"
+__version__ = "1.5"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/huesensor/device_tracker.py
+++ b/custom_components/huesensor/device_tracker.py
@@ -28,7 +28,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.util import slugify
 from homeassistant.components import zone
 
-__version__ = "1.4"
+__version__ = "1.5"
 
 DEPENDENCIES = ["hue"]
 

--- a/custom_components/huesensor/device_tracker.py
+++ b/custom_components/huesensor/device_tracker.py
@@ -42,11 +42,13 @@ def get_bridges(hass):
     from homeassistant.components import hue
     from homeassistant.components.hue.bridge import HueBridge
 
-    return [
-        entry
-        for entry in hass.data[hue.DOMAIN].values()
-        if isinstance(entry, HueBridge) and entry.api
-    ]
+    if(hue.DOMAIN in hass.data):
+        return [
+            entry
+            for entry in hass.data[hue.DOMAIN].values()
+            if isinstance(entry, HueBridge) and entry.api
+        ]
+    return False
 
 
 async def update_api(api):

--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 DEPENDENCIES = ["hue"]
 
-__version__ = "1.4"
+__version__ = "1.5"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -143,11 +143,13 @@ def get_bridges(hass):
     from homeassistant.components import hue
     from homeassistant.components.hue.bridge import HueBridge
 
-    return [
-        entry
-        for entry in hass.data[hue.DOMAIN].values()
-        if isinstance(entry, HueBridge) and entry.api
-    ]
+    if(hue.DOMAIN in hass.data):
+        return [
+            entry
+            for entry in hass.data[hue.DOMAIN].values()
+            if isinstance(entry, HueBridge) and entry.api
+        ]
+    return False
 
 
 async def update_api(api):

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,24 +1,24 @@
 {
    "device_tracker.hue" : {
-      "updated_at" : "2019-04-27",
+      "updated_at" : "2019-06-10",
       "local_location" : "/custom_components/huesensor/device_tracker.py",
-      "version" : "1.4",
+      "version" : "1.5",
       "changelog" : "https://github.com/robmarkcole/Hue-sensors-HASS/releases/latest",
       "visit_repo" : "https://github.com/robmarkcole/Hue-sensors-HASS",
       "remote_location" : "https://raw.githubusercontent.com/robmarkcole/Hue-sensors-HASS/master/custom_components/huesensor/device_tracker.py"
    },
    "binary_sensor.hue" : {
       "changelog" : "https://github.com/robmarkcole/Hue-sensors-HASS/releases/latest",
-      "version" : "1.4",
+      "version" : "1.5",
       "local_location" : "/custom_components/huesensor/binary_sensor.py",
-      "updated_at" : "2019-04-27",
+      "updated_at" : "2019-06-10",
       "visit_repo" : "https://github.com/robmarkcole/Hue-sensors-HASS",
       "remote_location" : "https://raw.githubusercontent.com/robmarkcole/Hue-sensors-HASS/master/custom_components/huesensor/binary_sensor.py"
    },
    "sensor.hue" : {
-      "version" : "1.4",
+      "version" : "1.5",
       "changelog" : "https://github.com/robmarkcole/Hue-sensors-HASS/releases/latest",
-      "updated_at" : "2019-04-27",
+      "updated_at" : "2019-06-10",
       "local_location" : "/custom_components/huesensor/sensor.py",
       "remote_location" : "https://raw.githubusercontent.com/robmarkcole/Hue-sensors-HASS/master/custom_components/huesensor/sensor.py",
       "visit_repo" : "https://github.com/robmarkcole/Hue-sensors-HASS"


### PR DESCRIPTION
Hello,

After upgrading to Home Assistant 0.94.x (or it also might have been hue bridge, which I updated at the same time) I started randomly encountering a new issue. Often after restart/start, huesensor would crash and not recover. This affected all domains, binary_sensor, device_tracker, and sensor.

```
Error while setting up platform huesensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 126, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 416, in wait_for
    return fut.result()
  File "/config/custom_components/huesensor/sensor.py", line 174, in async_setup_platform
    await data.async_update_info()
  File "/config/custom_components/huesensor/sensor.py", line 231, in async_update_info
    bridges = get_bridges(self.hass)
  File "/config/custom_components/huesensor/sensor.py", line 153, in get_bridges
    for entry in hass.data[hue.DOMAIN].values()
KeyError: 'hue'
```

The code provided should fix the issue, tested with restarts multiple times.