### PR TITLE
catch all unknown codes from TAP or FOH switches

### DIFF
--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -69,7 +69,7 @@ def parse_zgp(response):
     """Parse the json response for a ZGPSWITCH Hue Tap."""
     TAP_BUTTONS = {34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click"}
     press = response["state"]["buttonevent"]
-    if press is None:
+    if press is None or press not in TAP_BUTTONS:
         button = "No data"
     else:
         button = TAP_BUTTONS[press]
@@ -127,7 +127,7 @@ def parse_foh(response):
     }
     
     press = response['state']['buttonevent']
-    if press == None or press == 0 :
+    if press is None or press not in FOH_BUTTONS:
         button = 'No data'
     else:
         button =FOH_BUTTONS[press]


### PR DESCRIPTION
Recently I've made a pull request to be able to catch status code 0 in FoH switches. I've just bought a new switch and I'm getting new status codes I haven't seen yet. To make sure we can rest our case once and for all I've implemented the suggestion made by Clayton (cfr. https://github.com/robmarkcole/Hue-sensors-HASS/pull/143).

This means that from now on that faults are catched in a more lenient way and cannot break HASS sensor component on startup.