### PR TITLE
Added the new Lutron Aurora Switches

### DIFF
--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -56,10 +56,11 @@ ATTRS = {
     ],
 }
 
+
 def parse_hue_api_response(sensors):
     """Take in the Hue API json response."""
     data_dict = {}  # The list of sensors, referenced by their hue_id.
-    
+
     # Loop over all keys (1,2 etc) to identify sensors and get data.
     for sensor in sensors:
         modelid = sensor["modelid"][0:3]


### PR DESCRIPTION
Another Friends of Hue switch made by [Lutron:](http://www.lutron.com/en-US/Products/Pages/StandAloneControls/Dimmers-Switches/SmartBulbDimmer/overview.aspx)

The hue bridge treats it as two sensors, button and dial. However, I made it appear as one in HASS, with dial state as attributes.  Just like last time, its just an extension of existing functionality.

I'm not super familiar with python, so there may be tweaks needed. Feel free to make recommendations.