### PR TITLE
Fix unique ID issues

### DIFF
--- a/custom_components/huesensor/sensor.py
+++ b/custom_components/huesensor/sensor.py
@@ -56,10 +56,11 @@ ATTRS = {
     ],
 }
 
+
 def parse_hue_api_response(sensors):
     """Take in the Hue API json response."""
     data_dict = {}  # The list of sensors, referenced by their hue_id.
-    
+
     # Loop over all keys (1,2 etc) to identify sensors and get data.
     for sensor in sensors:
         modelid = sensor["modelid"][0:3]


### PR DESCRIPTION
I found some examples of TAP uniqueIDs online, they are the same form as FOH switches. (Are all sensors having the same form?) So, I made the substrings larger to ensure uniqueness for TAP (and FOH).

I removed the further slicing of the id in the HueSensor Class, since I believe #160 did not know they were already sliced up.

This should solve #162 and [this](https://community.home-assistant.io/t/hue-motion-sensors-remotes-custom-component/27176/1109?u=migbot).