### PR TITLE
Refactor code, merging remotes and sensors 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ ENV/
 # Rope project settings
 .ropeproject
 .vscode
+.idea

--- a/custom_components/huesensor/__init__.py
+++ b/custom_components/huesensor/__init__.py
@@ -1,13 +1,2 @@
 """The huesensors component."""
-from typing import List
-
-from homeassistant.components.hue import DOMAIN as HUE_DOMAIN, HueBridge
-
-
-def get_bridges(hass) -> List[HueBridge]:
-    """Retrieve Hue bridges from loaded official Hue integration."""
-    return [
-        entry
-        for entry in hass.data[HUE_DOMAIN].values()
-        if isinstance(entry, HueBridge) and entry.api
-    ]
+DOMAIN = "huesensor"

--- a/custom_components/huesensor/binary_sensor.py
+++ b/custom_components/huesensor/binary_sensor.py
@@ -166,7 +166,7 @@ class HueSensorData(object):
             self.sensors.update(new_entities)
             self.async_add_entities(new_entities.values(), True)
         for entity_id in updated_sensors:
-            self.sensors[entity_id].async_schedule_update_ha_state()
+            self.sensors[entity_id].async_write_ha_state()
 
     async def async_update_info(self, now=None):
         """Get the bridge info."""

--- a/custom_components/huesensor/binary_sensor.py
+++ b/custom_components/huesensor/binary_sensor.py
@@ -1,221 +1,46 @@
-"""
-Binary sensor for Hue motion sensors.
-"""
-import asyncio
+"""Binary sensor for Hue motion sensors."""
 import logging
-import threading
-from datetime import timedelta
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_SCAN_INTERVAL, STATE_OFF, STATE_ON
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.components.sensor import PLATFORM_SCHEMA  # noqa: F401
+from homeassistant.const import CONF_SCAN_INTERVAL, STATE_ON
 
-from . import get_bridges
-
+from . import DOMAIN
+from .data_manager import (
+    DEFAULT_SCAN_INTERVAL,
+    HueSensorBaseDevice,
+    HueSensorData,
+)
+from .hue_api_response import BINARY_SENSOR_MODELS
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=0.5)
 TYPE_GEOFENCE = "Geofence"
 DEVICE_CLASSES = {"SML": "motion"}
-ATTRS = {
-    "SML": [
-        "light_level",
-        "battery",
-        "last_updated",
-        "lx",
-        "dark",
-        "daylight",
-        "temperature",
-        "on",
-        "reachable",
-        "sensitivity",
-        "threshold_dark",
-        "threshold_offset",
-    ]
-}
 
 
-def parse_hue_api_response(sensors):
-    """Take in the Hue API json response."""
-    data_dict = {}  # The list of sensors, referenced by their hue_id.
-
-    # Loop over all keys (1,2 etc) to identify sensors and get data.
-    for sensor in sensors:
-        modelid = sensor["modelid"][0:3]
-        if modelid == "SML":
-            _key = modelid + "_" + sensor["uniqueid"][:-5]
-            if _key not in data_dict:
-                data_dict[_key] = parse_sml(sensor)
-            else:
-                data_dict[_key].update(parse_sml(sensor))
-
-    return data_dict
-
-
-def parse_sml(response):
-    """Parse the json for a SML Hue motion sensor and return the data."""
-    if response["type"] == "ZLLLightLevel":
-        lightlevel = response["state"]["lightlevel"]
-        tholddark = response["config"]["tholddark"]
-        tholdoffset = response["config"]["tholdoffset"]
-        if lightlevel is not None:
-            lx = round(float(10 ** ((lightlevel - 1) / 10000)), 2)
-            dark = response["state"]["dark"]
-            daylight = response["state"]["daylight"]
-            data = {
-                "light_level": lightlevel,
-                "lx": lx,
-                "dark": dark,
-                "daylight": daylight,
-                "threshold_dark": tholddark,
-                "threshold_offset": tholdoffset,
-            }
-        else:
-            data = {
-                "light_level": "No light level data",
-                "lx": None,
-                "dark": None,
-                "daylight": None,
-                "threshold_dark": None,
-                "threshold_offset": None,
-            }
-
-    elif response["type"] == "ZLLTemperature":
-        if response["state"]["temperature"] is not None:
-            data = {"temperature": response["state"]["temperature"] / 100.0}
-        else:
-            data = {"temperature": "No temperature data"}
-
-    elif response["type"] == "ZLLPresence":
-        name_raw = response["name"]
-        arr = name_raw.split()
-        arr.insert(-1, "motion")
-        name = " ".join(arr)
-        hue_state = response["state"]["presence"]
-        if hue_state is True:
-            state = STATE_ON
-        else:
-            state = STATE_OFF
-
-        data = {
-            "model": "SML",
-            "name": name,
-            "state": state,
-            "battery": response["config"]["battery"],
-            "on": response["config"]["on"],
-            "reachable": response["config"]["reachable"],
-            "sensitivity": response["config"]["sensitivity"],
-            "last_updated": response["state"]["lastupdated"].split("T"),
-        }
-    return data
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass, config, async_add_entities, discovery_info=None
+):
     """Initialise Hue Bridge connection."""
-    data = HueSensorData(hass, async_add_entities)
-    await data.async_update_info()
-    async_track_time_interval(
-        hass,
-        data.async_update_info,
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = HueSensorData(hass)
+
+    await hass.data[DOMAIN].async_add_platform_entities(
+        HueBinarySensor,
+        BINARY_SENSOR_MODELS,
+        async_add_entities,
         config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
     )
 
 
-class HueSensorData(object):
-    """Get the latest sensor data."""
-
-    def __init__(self, hass, async_add_entities):
-        """Initialize the data object."""
-        self.hass = hass
-        self.lock = threading.Lock()
-        self.data = {}
-        self.sensors = {}
-        self.async_add_entities = async_add_entities
-
-    async def update_bridge(self, bridge):
-        await bridge.sensor_manager.coordinator.async_request_refresh()
-
-        data = parse_hue_api_response(
-            sensor.raw
-            for sensor in bridge.api.sensors.values()
-            if sensor.type != TYPE_GEOFENCE
-        )
-
-        new_sensors = data.keys() - self.data.keys()
-        updated_sensors = []
-        for key, new in data.items():
-            new["changed"] = True
-            old = self.data.get(key)
-            if not old or old == new:
-                continue
-            updated_sensors.append(key)
-            if (
-                old["last_updated"] == new["last_updated"]
-                and old["state"] == new["state"]
-            ):
-                new["changed"] = False
-        self.data.update(data)
-
-        new_entities = {
-            entity_id: HueSensor(entity_id, self) for entity_id in new_sensors
-        }
-        if new_entities:
-            _LOGGER.debug("Created %s", ", ".join(new_entities.keys()))
-            self.sensors.update(new_entities)
-            self.async_add_entities(new_entities.values(), True)
-        for entity_id in updated_sensors:
-            self.sensors[entity_id].async_write_ha_state()
-
-    async def async_update_info(self, now=None):
-        """Get the bridge info."""
-        locked = self.lock.acquire(False)
-        if not locked:
-            return
-        try:
-            bridges = get_bridges(self.hass)
-            if not bridges:
-                if now:
-                    # periodic task
-                    await asyncio.sleep(5)
-                return
-            await asyncio.wait(
-                [self.update_bridge(bridge) for bridge in bridges], loop=self.hass.loop
-            )
-        finally:
-            self.lock.release()
-
-
-class HueSensor(BinarySensorDevice):
-    """Class to hold Hue Sensor basic info."""
-
-    def __init__(self, hue_id, data):
-        """Initialize the sensor object."""
-        self._hue_id = hue_id
-        self._data = data.data  # data is in .data
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        data = self._data.get(self._hue_id)
-        if data:
-            return data["name"]
-
-    @property
-    def unique_id(self):
-        """Return the ID of this Hue sensor."""
-        return self._hue_id
+class HueBinarySensor(HueSensorBaseDevice, BinarySensorDevice):
+    """Class to hold Hue Binary Sensor basic info."""
 
     @property
     def is_on(self):
         """Return the state of the sensor."""
-        data = self._data.get(self._hue_id)
+        data = self.sensor_data
         if data and data["model"] == "SML" and data["changed"]:
             return data["state"] == STATE_ON
         return False
@@ -223,15 +48,4 @@ class HueSensor(BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
-        data = self._data.get(self._hue_id)
-        if data:
-            device_class = DEVICE_CLASSES.get(data["model"])
-            if device_class:
-                return device_class
-
-    @property
-    def device_state_attributes(self):
-        """Attributes."""
-        data = self._data.get(self._hue_id)
-        if data:
-            return {key: data.get(key) for key in ATTRS.get(data["model"], [])}
+        return DEVICE_CLASSES.get(self.sensor_data["model"])

--- a/custom_components/huesensor/binary_sensor.py
+++ b/custom_components/huesensor/binary_sensor.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import CONF_SCAN_INTERVAL, STATE_OFF, STATE_ON
 from homeassistant.helpers.event import async_track_time_interval
 
 from . import get_bridges
@@ -16,7 +16,7 @@ from . import get_bridges
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=0.5)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=0.5)
 TYPE_GEOFENCE = "Geofence"
 DEVICE_CLASSES = {"SML": "motion"}
 ATTRS = {
@@ -116,7 +116,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Initialise Hue Bridge connection."""
     data = HueSensorData(hass, async_add_entities)
     await data.async_update_info()
-    async_track_time_interval(hass, data.async_update_info, SCAN_INTERVAL)
+    async_track_time_interval(
+        hass,
+        data.async_update_info,
+        config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+    )
 
 
 class HueSensorData(object):

--- a/custom_components/huesensor/data_manager.py
+++ b/custom_components/huesensor/data_manager.py
@@ -1,0 +1,207 @@
+"""The huesensors component."""
+import asyncio
+from datetime import timedelta
+import logging
+from typing import AsyncIterable, List, Tuple
+
+from homeassistant.components.hue import DOMAIN as HUE_DOMAIN, HueBridge
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
+
+from .hue_api_response import parse_hue_api_response, ENTITY_ATTRS
+
+_LOGGER = logging.getLogger(__name__)
+
+# Scan interval for remotes and binary sensors is set to < 1s
+# just to ~ensure that an update is called for each HA tick,
+# as using an exact 1s misses some of the ticks
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=0.5)
+
+
+def get_bridges(hass) -> List[HueBridge]:
+    """Retrieve Hue bridges from loaded official Hue integration."""
+    return [
+        entry
+        for entry in hass.data[HUE_DOMAIN].values()
+        if isinstance(entry, HueBridge) and entry.api
+    ]
+
+
+class HueSensorData:
+    """Get the latest sensor data."""
+    """Sensor data handler for this custom integration."""
+
+    def __init__(self, hass):
+        """Initialize the data object."""
+        self.hass = hass
+        self.lock = asyncio.Lock()
+        self.data = {}
+        self.sensors = {}
+        self.available = False
+        self._scan_interval = None
+        self._update_listener = None
+
+    async def _iter_data(self) -> AsyncIterable[Tuple[bool, str, str, dict]]:
+        for bridge in get_bridges(self.hass):
+            await bridge.sensor_manager.coordinator.async_request_refresh()
+            data = parse_hue_api_response(
+                sensor.raw for sensor in bridge.api.sensors.values()
+            )
+            for dev_id, dev_data in data.items():
+                updated = False
+                dev_model = dev_data["model"]
+                if dev_model == "SML":
+                    dev_data["changed"] = True
+                old = self.data.get(dev_id)
+                if not old:
+                    updated = True
+                    self.data[dev_id] = dev_data
+                elif old != dev_data:
+                    updated = True
+                    if (
+                        old["last_updated"] == dev_data["last_updated"]
+                        and old["state"] == dev_data["state"]
+                    ):
+                        if dev_model == "SML":
+                            dev_data["changed"] = False
+                        updated = False
+                    self.data[dev_id].update(dev_data)
+
+                yield updated, dev_data["model"], dev_id, dev_data
+
+    async def async_start_scheduler(self):
+        """Schedule data polling with current scan_interval."""
+        async with self.lock:
+            if self.available:
+                return
+
+            if self._update_listener is not None:
+                _LOGGER.info(f"Cancelling old time tracker")
+                self._update_listener()
+            self._update_listener = async_track_time_interval(
+                self.hass, self.async_update_from_bridges, self._scan_interval,
+            )
+            self.available = True
+
+    async def async_stop_scheduler(self):
+        """Cancel data polling with current scan_interval."""
+        async with self.lock:
+            if not self.available and self._update_listener is None:
+                _LOGGER.debug(f"Already stopped")
+                return
+
+            if self._update_listener is not None:
+                _LOGGER.debug(f"Cancelling time tracker")
+                self._update_listener()
+                self._update_listener = None
+
+            self.available = False
+        _LOGGER.debug(f"Stopped polling with {self._scan_interval}")
+
+    async def async_add_platform_entities(
+        self, entity_cls, platform_models, async_add_entities, scan_interval,
+    ):
+        """Add sensor entities from platform setups."""
+        new_entities = []
+        async for updated, model, dev_id, dev_data in self._iter_data():
+            if model in platform_models and dev_id not in self.sensors:
+                platform_entity = entity_cls(dev_id, self)
+                self.sensors[dev_id] = platform_entity
+                new_entities.append(platform_entity)
+
+        if new_entities:
+            async_add_entities(new_entities, True)
+
+            if self._scan_interval is None:
+                self._scan_interval = scan_interval
+                _LOGGER.info(
+                    "Configure a scan_interval of %.2f s for %s devices",
+                    scan_interval.total_seconds(),
+                    entity_cls.__name__,
+                )
+            elif scan_interval < self._scan_interval:
+                _LOGGER.info(
+                    "Re-Configure a scan_interval of %.2f s for %s devices"
+                    " (before it was %.2f s)",
+                    scan_interval.total_seconds(),
+                    entity_cls.__name__,
+                    self._scan_interval.total_seconds(),
+                )
+                await self.async_stop_scheduler()
+                self._scan_interval = scan_interval
+
+    async def async_update_from_bridges(self, now=None):
+        """Request data from bridges and update sensors data."""
+        async for updated, _, dev_id, _ in self._iter_data():
+            if updated:
+                self.sensors[dev_id].async_write_ha_state()
+                _LOGGER.debug(
+                    "%s (%s): updated with state=%s",
+                    self.sensors[dev_id].entity_id,
+                    dev_id,
+                    self.sensors[dev_id].state,
+                )
+
+
+class HueSensorBaseDevice(Entity):
+    """Common class to handle custom HueSensor entities."""
+
+    def __init__(self, hue_id, data_manager: HueSensorData):
+        """Initialize the hue object."""
+        self._hue_id = hue_id
+        self._data_manager = data_manager
+
+    async def async_added_to_hass(self):
+        """When entity is added to hass."""
+        # TODO use bridge.sensor_manager.coordinator.async_add_listener
+        # self.bridge.sensor_manager.coordinator.async_add_listener(
+        #     self.async_write_ha_state
+        # )
+        await self._data_manager.async_start_scheduler()
+        _LOGGER.debug(
+            "%s: setup complete for %s:%s", self.entity_id,
+            self.__class__.__name__,
+            self._hue_id,
+        )
+
+    async def async_will_remove_from_hass(self):
+        """When entity will be removed from hass."""
+        # self.bridge.sensor_manager.coordinator.async_remove_listener(
+        #     self.async_write_ha_state
+        # )
+        _LOGGER.warning("%s: Removing entity from HA", self.entity_id)
+        self._data_manager.sensors.pop(self._hue_id)
+
+        if self._data_manager.sensors:
+            return
+
+        await self._data_manager.async_stop_scheduler()
+
+    @property
+    def sensor_data(self) -> dict:
+        """Access to parsed sensor data."""
+        return self._data_manager.data.get(self._hue_id)
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the remote."""
+        return self.sensor_data["name"]
+
+    @property
+    def unique_id(self):
+        """Return the ID of this Hue remote."""
+        return self._hue_id
+
+    @property
+    def device_state_attributes(self):
+        """Attributes."""
+        data = self.sensor_data
+        if not data:
+            _LOGGER.info(f"Ignoring {self.entity_id}")
+            return {}
+        return {key: data.get(key) for key in ENTITY_ATTRS.get(data["model"], [])}

--- a/custom_components/huesensor/device_tracker.py
+++ b/custom_components/huesensor/device_tracker.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import slugify
 
-from . import get_bridges
+from .data_manager import get_bridges
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/huesensor/hue_api_response.py
+++ b/custom_components/huesensor/hue_api_response.py
@@ -1,0 +1,265 @@
+"""Hue API data parsing for sensors."""
+import logging
+from homeassistant.const import STATE_OFF, STATE_ON
+
+REMOTE_MODELS = ["RWL", "ROM", "FOH", "ZGP", "Z3-"]
+BINARY_SENSOR_MODELS = ["SML"]
+ENTITY_ATTRS = {
+    "RWL": ["last_updated", "last_button_event", "battery", "on", "reachable"],
+    "ROM": ["last_updated", "last_button_event", "battery", "on", "reachable"],
+    "ZGP": ["last_updated", "last_button_event"],
+    "FOH": ["last_updated", "last_button_event"],
+    "Z3-": [
+        "last_updated",
+        "last_button_event",
+        "battery",
+        "on",
+        "reachable",
+        "dial_state",
+        "dial_position",
+        "software_update",
+    ],
+    "SML": [
+        "light_level",
+        "battery",
+        "last_updated",
+        "lx",
+        "dark",
+        "daylight",
+        "temperature",
+        "on",
+        "reachable",
+        "sensitivity",
+        "threshold_dark",
+        "threshold_offset",
+    ],
+}
+FOH_BUTTONS = {
+    16: "left_upper_press",
+    20: "left_upper_release",
+    17: "left_lower_press",
+    21: "left_lower_release",
+    18: "right_lower_press",
+    22: "right_lower_release",
+    19: "right_upper_press",
+    23: "right_upper_release",
+    100: "double_upper_press",
+    101: "double_upper_release",
+    98: "double_lower_press",
+    99: "double_lower_release",
+}
+RWL_RESPONSE_CODES = {
+    "0": "_click", "1": "_hold", "2": "_click_up", "3": "_hold_up"
+}
+TAP_BUTTONS = {34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click"}
+Z3_BUTTON = {
+    1000: "initial_press",
+    1001: "repeat",
+    1002: "short_release",
+    1003: "long_release",
+}
+Z3_DIAL = {1: "begin", 2: "end"}
+
+
+def parse_sml(response):
+    """Parse the json for a SML Hue motion sensor and return the data."""
+    data = {}
+    if response["type"] == "ZLLLightLevel":
+        lightlevel = response["state"]["lightlevel"]
+        tholddark = response["config"]["tholddark"]
+        tholdoffset = response["config"]["tholdoffset"]
+        if lightlevel is not None:
+            lx = round(float(10 ** ((lightlevel - 1) / 10000)), 2)
+            dark = response["state"]["dark"]
+            daylight = response["state"]["daylight"]
+            data = {
+                "light_level": lightlevel,
+                "lx": lx,
+                "dark": dark,
+                "daylight": daylight,
+                "threshold_dark": tholddark,
+                "threshold_offset": tholdoffset,
+            }
+        else:
+            data = {
+                "light_level": "No light level data",
+                "lx": None,
+                "dark": None,
+                "daylight": None,
+                "threshold_dark": None,
+                "threshold_offset": None,
+            }
+
+    elif response["type"] == "ZLLTemperature":
+        if response["state"]["temperature"] is not None:
+            data = {"temperature": response["state"]["temperature"] / 100.0}
+        else:
+            data = {"temperature": "No temperature data"}
+
+    elif response["type"] == "ZLLPresence":
+        name_raw = response["name"]
+        arr = name_raw.split()
+        arr.insert(-1, "motion")
+        name = " ".join(arr)
+        hue_state = response["state"]["presence"]
+        if hue_state is True:
+            state = STATE_ON
+        else:
+            state = STATE_OFF
+
+        data = {
+            "model": "SML",
+            "name": name,
+            "state": state,
+            "battery": response["config"]["battery"],
+            "on": response["config"]["on"],
+            "reachable": response["config"]["reachable"],
+            "sensitivity": response["config"]["sensitivity"],
+            "last_updated": response["state"]["lastupdated"].split("T"),
+        }
+    return data
+
+
+def parse_zgp(response):
+    """Parse the json response for a ZGPSWITCH Hue Tap."""
+    press = response["state"]["buttonevent"]
+    if press is None or press not in TAP_BUTTONS:
+        button = "No data"
+    else:
+        button = TAP_BUTTONS[press]
+
+    data = {
+        "model": "ZGP",
+        "name": response["name"],
+        "state": button,
+        "last_button_event": button,
+        "last_updated": response["state"]["lastupdated"].split("T"),
+    }
+    return data
+
+
+def parse_rwl(response):
+    """Parse the json response for a RWL Hue remote."""
+    button = None
+    if response["state"]["buttonevent"]:
+        press = str(response["state"]["buttonevent"])
+        button = str(press)[0] + RWL_RESPONSE_CODES[press[-1]]
+
+    data = {
+        "model": "RWL",
+        "name": response["name"],
+        "state": button,
+        "battery": response["config"]["battery"],
+        "on": response["config"]["on"],
+        "reachable": response["config"]["reachable"],
+        "last_button_event": button,
+        "last_updated": response["state"]["lastupdated"].split("T"),
+    }
+    return data
+
+
+def parse_foh(response):
+    """Parse the JSON response for a FOHSWITCH (type still = ZGPSwitch)."""
+    press = response["state"]["buttonevent"]
+    if press is None or press not in FOH_BUTTONS:
+        button = "No data"
+    else:
+        button = FOH_BUTTONS[press]
+
+    data = {
+        "model": "FOH",
+        "name": response["name"],
+        "state": button,
+        "last_button_event": button,
+        "last_updated": response["state"]["lastupdated"].split("T"),
+    }
+    return data
+
+
+def parse_z3_rotary(response):
+    """Parse the json response for a Lutron Aurora Rotary Event."""
+    logging.warning(response)
+    turn = response["state"]["rotaryevent"]
+    dial_position = response["state"]["expectedrotation"]
+    if turn is None or turn not in Z3_DIAL:
+        dial = "No data"
+    else:
+        dial = Z3_DIAL[turn]
+
+    data = {
+        "model": "Z3-",
+        "name": response["name"],
+        "dial_state": dial,
+        "dial_position": dial_position,
+        "software_update": response["swupdate"]["state"],
+        "battery": response["config"]["battery"],
+        "on": response["config"]["on"],
+        "reachable": response["config"]["reachable"],
+        "last_updated": response["state"]["lastupdated"].split("T"),
+    }
+    return data
+
+
+def parse_z3_switch(response):
+    """Parse the json response for a Lutron Aurora."""
+    press = response["state"]["buttonevent"]
+    logging.warning(press)
+    if press is None or press not in Z3_BUTTON:
+        button = "No data"
+    else:
+        button = Z3_BUTTON[press]
+
+    data = {
+        "last_button_event": button,
+        "state": button,
+        "last_updated": response["state"]["lastupdated"].split("T"),
+    }
+    return data
+
+
+def parse_hue_api_response(sensors):
+    """Take in the Hue API json response."""
+    data_dict = {}  # The list of sensors, referenced by their hue_id.
+
+    # Loop over all keys (1,2 etc) to identify sensors and get data.
+    for sensor in sensors:
+        modelid = sensor["modelid"][0:3]
+        if modelid == "SML":
+            _key = modelid + "_" + sensor["uniqueid"][:-5]
+            if _key not in data_dict:
+                data_dict[_key] = parse_sml(sensor)
+            else:
+                data_dict[_key].update(parse_sml(sensor))
+        elif modelid in ["RWL", "ROM"]:
+            _key = modelid + "_" + sensor["uniqueid"][:-5]
+            if modelid == "RWL" or modelid == "ROM":
+                data_dict[_key] = parse_rwl(sensor)
+
+        elif modelid in ["FOH", "ZGP"]:
+            # **** New Model ID ****
+            # needed for uniqueness
+            _key = modelid + "_" + sensor["uniqueid"][-14:-3]
+            if modelid == "FOH":
+                data_dict[_key] = parse_foh(sensor)
+            elif modelid == "ZGP":
+                data_dict[_key] = parse_zgp(sensor)
+
+        elif modelid == "Z3-":
+            # Newest Model ID / Lutron Aurora / Hue Bridge
+            # treats it as two sensors, I wanted them combined
+            if sensor["type"] == "ZLLRelativeRotary":  # Rotary Dial
+                _key = (
+                    modelid + "_" + sensor["uniqueid"][:-5]
+                )  # Rotary key is substring of button
+                key_value = parse_z3_rotary(sensor)
+            else:
+                _key = modelid + "_" + sensor["uniqueid"]
+                key_value = parse_z3_switch(sensor)
+
+            # Combine parsed data
+            if _key in data_dict:
+                data_dict[_key].update(key_value)
+            else:
+                data_dict[_key] = key_value
+
+    return data_dict

--- a/custom_components/huesensor/remote.py
+++ b/custom_components/huesensor/remote.py
@@ -1,25 +1,20 @@
-"""
-Hue remotes.
-"""
-import asyncio
+"""Hue remotes."""
 import logging
-import threading
-from datetime import timedelta
 
 from homeassistant.const import CONF_SCAN_INTERVAL
-from homeassistant.components.hue import HueBridge
-from homeassistant.components.remote import PLATFORM_SCHEMA, RemoteDevice
-from homeassistant.helpers.entity import Entity, ToggleEntity
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.components.remote import PLATFORM_SCHEMA, RemoteDevice  # noqa: F401
 
-from . import get_bridges
-
+from . import DOMAIN
+from .data_manager import (
+    DEFAULT_SCAN_INTERVAL,
+    HueSensorBaseDevice,
+    HueSensorData,
+)
+from .hue_api_response import REMOTE_MODELS
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=0.5)
-
-ICONS = {
+REMOTE_ICONS = {
     "RWL": "mdi:remote",
     "ROM": "mdi:remote",
     "ZGP": "mdi:remote",
@@ -27,324 +22,40 @@ ICONS = {
     "Z3-": "mdi:light-switch",
 }
 
-ATTRS = {
-    "RWL": ["last_updated", "last_button_event", "battery", "on", "reachable"],
-    "ROM": ["last_updated", "last_button_event", "battery", "on", "reachable"],
-    "ZGP": ["last_updated", "last_button_event"],
-    "FOH": ["last_updated", "last_button_event"],
-    "Z3-": [
-        "last_updated",
-        "last_button_event",
-        "battery",
-        "on",
-        "reachable",
-        "dial_state",
-        "dial_position",
-        "software_update",
-    ],
-}
 
-
-def parse_hue_api_response(sensors):
-    """Take in the Hue API json response."""
-    data_dict = {}  # The list of sensors, referenced by their hue_id.
-
-    # Loop over all keys (1,2 etc) to identify sensors and get data.
-    for sensor in sensors:
-        modelid = sensor["modelid"][0:3]
-        if modelid in ["RWL", "ROM"]:
-            _key = modelid + "_" + sensor["uniqueid"][:-5]
-            if modelid == "RWL" or modelid == "ROM":
-                data_dict[_key] = parse_rwl(sensor)
-
-        elif modelid in ["FOH", "ZGP"]:  ############# New Model ID
-            _key = modelid + "_" + sensor["uniqueid"][-14:-3]  ###needed for uniqueness
-            if modelid == "FOH":
-                data_dict[_key] = parse_foh(sensor)
-            elif modelid == "ZGP":
-                data_dict[_key] = parse_zgp(sensor)
-
-        elif (
-            modelid == "Z3-"
-        ):  # Newest Model ID / Lutron Aurora / Hue Bridge treats it as two sensors, I wanted them combined
-            if sensor["type"] == "ZLLRelativeRotary":  # Rotary Dial
-                _key = (
-                    modelid + "_" + sensor["uniqueid"][:-5]
-                )  # Rotary key is substring of button
-                key_value = parse_z3_rotary(sensor)
-            else:
-                _key = modelid + "_" + sensor["uniqueid"]
-                key_value = parse_z3_switch(sensor)
-
-            # Combine parsed data
-            if _key in data_dict:
-                data_dict[_key].update(key_value)
-            else:
-                data_dict[_key] = key_value
-
-    return data_dict
-
-
-def parse_zgp(response):
-    """Parse the json response for a ZGPSWITCH Hue Tap."""
-    TAP_BUTTONS = {34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click"}
-    press = response["state"]["buttonevent"]
-    if press is None or press not in TAP_BUTTONS:
-        button = "No data"
-    else:
-        button = TAP_BUTTONS[press]
-
-    data = {
-        "model": "ZGP",
-        "name": response["name"],
-        "state": button,
-        "last_button_event": button,
-        "last_updated": response["state"]["lastupdated"].split("T"),
-    }
-    return data
-
-
-def parse_rwl(response):
-    """Parse the json response for a RWL Hue remote."""
-    responsecodes = {"0": "_click", "1": "_hold", "2": "_click_up", "3": "_hold_up"}
-
-    button = None
-    if response["state"]["buttonevent"]:
-        press = str(response["state"]["buttonevent"])
-        button = str(press)[0] + responsecodes[press[-1]]
-
-    data = {
-        "model": "RWL",
-        "name": response["name"],
-        "state": button,
-        "battery": response["config"]["battery"],
-        "on": response["config"]["on"],
-        "reachable": response["config"]["reachable"],
-        "last_button_event": button,
-        "last_updated": response["state"]["lastupdated"].split("T"),
-    }
-    return data
-
-
-def parse_foh(response):
-    """Parse the JSON response for a FOHSWITCH (type still = ZGPSwitch)"""
-    FOH_BUTTONS = {
-        16: "left_upper_press",
-        20: "left_upper_release",
-        17: "left_lower_press",
-        21: "left_lower_release",
-        18: "right_lower_press",
-        22: "right_lower_release",
-        19: "right_upper_press",
-        23: "right_upper_release",
-        100: "double_upper_press",
-        101: "double_upper_release",
-        98: "double_lower_press",
-        99: "double_lower_release",
-    }
-
-    press = response["state"]["buttonevent"]
-    if press is None or press not in FOH_BUTTONS:
-        button = "No data"
-    else:
-        button = FOH_BUTTONS[press]
-
-    data = {
-        "model": "FOH",
-        "name": response["name"],
-        "state": button,
-        "last_button_event": button,
-        "last_updated": response["state"]["lastupdated"].split("T"),
-    }
-    return data
-
-
-def parse_z3_rotary(response):
-    """Parse the json response for a Lutron Aurora Rotary Event."""
-
-    Z3_DIAL = {1: "begin", 2: "end"}
-
-    turn = response["state"]["rotaryevent"]
-    dial_position = response["state"]["expectedrotation"]
-    if turn is None or turn not in Z3_DIAL:
-        dial = "No data"
-    else:
-        dial = Z3_DIAL[turn]
-
-    data = {
-        "model": "Z3-",
-        "name": response["name"],
-        "dial_state": dial,
-        "dial_position": dial_position,
-        "software_update": response["swupdate"]["state"],
-        "battery": response["config"]["battery"],
-        "on": response["config"]["on"],
-        "reachable": response["config"]["reachable"],
-        "last_updated": response["state"]["lastupdated"].split("T"),
-    }
-    return data
-
-
-def parse_z3_switch(response):
-    """Parse the json response for a Lutron Aurora."""
-
-    Z3_BUTTON = {
-        1000: "initial_press",
-        1001: "repeat",
-        1002: "short_release",
-        1003: "long_release",
-    }
-
-    press = response["state"]["buttonevent"]
-    if press is None or press not in Z3_BUTTON:
-        button = "No data"
-    else:
-        button = Z3_BUTTON[press]
-
-    data = {"last_button_event": button, "state": button}
-    return data
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass, config, async_add_entities, discovery_info=None
+):
     """Initialise Hue Bridge connection."""
-    _LOGGER.warning(f"config: {config}")
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = HueSensorData(hass)
 
-    data = HueRemoteData(hass, async_add_entities)
-    await data.async_update_info()
-    async_track_time_interval(
-        hass,
-        data.async_update_info,
+    await hass.data[DOMAIN].async_add_platform_entities(
+        HueRemote,
+        REMOTE_MODELS,
+        async_add_entities,
         config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
     )
 
 
-class HueRemoteData(object):
-    """Get the latest sensor data."""
-
-    def __init__(self, hass, async_add_entities):
-        """Initialize the data object."""
-        self.hass = hass
-        self.lock = threading.Lock()
-        self.data = {}
-        self.sensors = {}
-        self.async_add_entities = async_add_entities
-
-    async def update_bridge(self, bridge: HueBridge):
-        await bridge.sensor_manager.coordinator.async_request_refresh()
-
-        data = parse_hue_api_response(
-            sensor.raw for sensor in bridge.api.sensors.values()
-        )
-
-        new_sensors = data.keys() - self.data.keys()
-        updated_sensors = []
-        for key, new in data.items():
-            old = self.data.get(key)
-            if not old or old == new:
-                continue
-            if (
-                old["last_updated"] == new["last_updated"]
-                and old["state"] == new["state"]
-            ):
-                continue
-            updated_sensors.append(key)
-        self.data.update(data)
-
-        new_entities = {
-            entity_id: HueRemote(entity_id, self) for entity_id in new_sensors
-        }
-        if new_entities:
-            _LOGGER.warning("Created %s", ", ".join(new_entities.keys()))
-            self.sensors.update(new_entities)
-            self.async_add_entities(new_entities.values(), True)
-        for entity_id in updated_sensors:
-            self.sensors[entity_id].async_write_ha_state()
-
-    async def async_update_info(self, now=None):
-        """Get the bridge info."""
-        locked = self.lock.acquire(False)
-        if not locked:
-            return
-        try:
-            bridges = get_bridges(self.hass)
-            if not bridges:
-                if now:
-                    # periodic task
-                    await asyncio.sleep(5)
-                return
-            await asyncio.wait(
-                [self.update_bridge(bridge) for bridge in bridges], loop=self.hass.loop
-            )
-        finally:
-            self.lock.release()
-
-
-class HueRemote(RemoteDevice):
+class HueRemote(HueSensorBaseDevice, RemoteDevice):
     """Class to hold Hue Remote basic info."""
-
-    def __init__(self, hue_id, data):
-        """Initialize the remote object."""
-        self._hue_id = hue_id
-        self._data = data.data  # data is in .data
-
-    # async def async_added_to_hass(self):
-    #     """When entity is added to hass."""
-    #     self.bridge.sensor_manager.coordinator.async_add_listener(
-    #         self.async_write_ha_state
-    #     )
-    #
-    # async def async_will_remove_from_hass(self):
-    #     """When entity will be removed from hass."""
-    #     self.bridge.sensor_manager.coordinator.async_remove_listener(
-    #         self.async_write_ha_state
-    #     )
-    #
-    # async def async_update(self):
-    #     """Update the entity.
-    #
-    #     Only used by the generic entity update service.
-    #     """
-    #     await self.bridge.sensor_manager.coordinator.async_request_refresh()
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
-
-    @property
-    def name(self):
-        """Return the name of the remote."""
-        data = self._data.get(self._hue_id)
-        if data:
-            return data["name"]
-
-    @property
-    def unique_id(self):
-        """Return the ID of this Hue remote."""
-        return self._hue_id
 
     @property
     def state(self):
         """Return the state of the remote."""
-        data = self._data.get(self._hue_id)
-        return data["state"]
+        return self.sensor_data["state"]
 
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        data = self._data.get(self._hue_id)
+        data = self.sensor_data
         if data:
-            icon = ICONS.get(data["model"])
+            icon = REMOTE_ICONS.get(data["model"])
             if icon:
                 return icon
-        return self.ICON
-
-    @property
-    def device_state_attributes(self):
-        """Attributes."""
-        data = self._data.get(self._hue_id)
-        if data:
-            return {key: data.get(key) for key in ATTRS.get(data["model"], [])}
+        _LOGGER.warning(f"No icon found for {self.entity_id}")
+        return "mdi:remote"
 
     @property
     def force_update(self):

--- a/custom_components/huesensor/remote.py
+++ b/custom_components/huesensor/remote.py
@@ -258,7 +258,7 @@ class HueRemoteData(object):
             self.sensors.update(new_entities)
             self.async_add_entities(new_entities.values(), True)
         for entity_id in updated_sensors:
-            self.sensors[entity_id].async_schedule_update_ha_state()
+            self.sensors[entity_id].async_write_ha_state()
 
     async def async_update_info(self, now=None):
         """Get the bridge info."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,7 +1,5 @@
-"""
-Tests for binary_sensor.py
-"""
-import custom_components.huesensor.binary_sensor as bs
+"""Tests for binary_sensor.py."""
+from custom_components.huesensor.hue_api_response import parse_sml
 
 MOCK_ZLLPresence = {
     "state": {"presence": False, "lastupdated": "2020-02-06T07:28:08"},
@@ -102,6 +100,6 @@ PARSED_ZLLTemperature = {"temperature": 17.44}
 
 
 def test_parse_sml():
-    assert bs.parse_sml(MOCK_ZLLPresence) == PARSED_ZLLPresence
-    assert bs.parse_sml(MOCK_ZLLLightlevel) == PARSED_ZLLLightlevel
-    assert bs.parse_sml(MOCK_ZLLTemperature) == PARSED_ZLLTemperature
+    assert parse_sml(MOCK_ZLLPresence) == PARSED_ZLLPresence
+    assert parse_sml(MOCK_ZLLLightlevel) == PARSED_ZLLLightlevel
+    assert parse_sml(MOCK_ZLLTemperature) == PARSED_ZLLTemperature

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,7 +1,9 @@
-"""
-Tests for binary_sensor.py
-"""
-import custom_components.huesensor.remote as remote
+"""Tests for remote.py."""
+from custom_components.huesensor.hue_api_response import (
+    parse_rwl,
+    parse_zgp,
+    parse_z3_rotary,
+)
 
 MOCK_ZGP = {
     "state": {"buttonevent": 17, "lastupdated": "2019-06-22T14:43:50"},
@@ -14,9 +16,8 @@ MOCK_ZGP = {
     "productname": "Hue tap switch",
     "diversityid": "d8cde5d5-0eef-4b95-b0f0-71ddd2952af4",
     "uniqueid": "00:00:00:00:00:44:23:08-f2",
-    "capabilities": {"certified": True, "primary": True, "inputs": [],},
+    "capabilities": {"certified": True, "primary": True, "inputs": []},
 }
-
 MOCK_RWL = {
     "state": {"buttonevent": 4002, "lastupdated": "2019-12-28T21:58:02"},
     "swupdate": {"state": "noupdates", "lastinstall": "2019-10-13T13:16:15"},
@@ -31,6 +32,37 @@ MOCK_RWL = {
     "uniqueid": "00:17:88:01:10:3e:3a:dc-02-fc00",
     "capabilities": {"certified": True, "primary": True, "inputs": []},
 }
+MOCK_Z3_ROTARY = {
+    "state": {
+        "rotaryevent": 2,
+        "expectedrotation": 208,
+        "expectedeventduration": 400,
+        "lastupdated": "2020-01-31T15:56:19",
+    },
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-11-26T03:35:21"},
+    "config": {"on": True, "battery": 100, "reachable": True, "pending": []},
+    "name": "Lutron Aurora 1",
+    "type": "ZLLRelativeRotary",
+    "modelid": "Z3-1BRL",
+    "manufacturername": "Lutron",
+    "productname": "Lutron Aurora",
+    "diversityid": "2c3a75ff-55c4-4e4d-8c44-82d330b8eb9b",
+    "swversion": "3.4",
+    "uniqueid": "ff:ff:00:0f:e7:fd:ba:b7-01-fc00-0014",
+    "capabilities": {
+        "certified": True,
+        "primary": True,
+        "inputs": [
+            {
+                "repeatintervals": [400],
+                "events": [
+                    {"rotaryevent": 1, "eventtype": "start"},
+                    {"rotaryevent": 2, "eventtype": "repeat"},
+                ],
+            }
+        ],
+    },
+}
 
 PARSED_ZGP = {
     "last_button_event": "3_click",
@@ -39,7 +71,6 @@ PARSED_ZGP = {
     "name": "Hue Tap",
     "state": "3_click",
 }
-
 PARSED_RWL = {
     "battery": 100,
     "last_button_event": "4_click_up",
@@ -50,8 +81,20 @@ PARSED_RWL = {
     "reachable": True,
     "state": "4_click_up",
 }
+PARSED_Z3_ROTARY = {
+    "model": "Z3-",
+    "name": "Lutron Aurora 1",
+    "dial_state": "end",
+    "dial_position": 208,
+    "software_update": "noupdates",
+    "battery": 100,
+    "on": True,
+    "reachable": True,
+    "last_updated": ["2020-01-31", "15:56:19"],
+}
 
 
 def test_parse_zgp():
-    assert remote.parse_zgp(MOCK_ZGP) == PARSED_ZGP
-    assert remote.parse_rwl(MOCK_RWL) == PARSED_RWL
+    assert parse_zgp(MOCK_ZGP) == PARSED_ZGP
+    assert parse_rwl(MOCK_RWL) == PARSED_RWL
+    assert parse_z3_rotary(MOCK_Z3_ROTARY) == PARSED_Z3_ROTARY


### PR DESCRIPTION
cc @robmarkcole 

### Description

Remove duplicated code in binary_sensor and remote platforms, and merge the data source for them.

closes #194, #193 

And it should also close #215 

### Changes

- Add a new `HueSensorData` handler in `data_manager.py`, to use the same time tracker and make the update for all entities at once.
- Optionally define the `scan_interval` for each platform (but it will just use the minor one for both platforms, and the default is the same as before: 0.5s )
- Scheduling starts in `added_to_hass`, so no updates are done before that (we could implement `RestoreEntity` to load the last state on that point, eventually)
- Small optimization: use `async_write_ha_state` callback instead of scheduling updates for each entity.
- Ready to use better HA registry, so entities could appear under integrations with small changes.
- Also easier to add new devices, as now all the parsing logic is centralized in `hue_api_response.py`.
- A new `HueSensorBaseDevice` has been refactored from old remote and bs class entities, as most of the methods were the same for both platforms.

### Implications

- Only 1 call to the Hue bridge for all remotes and binary sensors
- That call is shared with the HA Core hue integration (so, _as collateral_, the configured sensors there will have the same high update frequency than the remotes)
- The default frequency for that one call is 1Hz (:= `scan_interval=1.0`, but using 0.5 to reduce missing ticks, see discussion on #194 )

### Usage recommendations

If sub-second delay is not critical for you, but the 5 seconds of the official integration for sensors is too much, and you have remotes (not implemented in HA Core yet), the best configuration would be something like this:

```yaml
remote:
  - platform: huesensor
    scan_interval: 2
```

With that, and configuring the binary sensors in HA Core, **both remotes and sensors** will have a 2-sec update rate.

### Notes

- `device_tracker` is untouched, as it uses a scan_interval of 30s (and I'm not so sure about its destiny)
- Entity availability, linking with the hue integration, is not implemented. In situations of connection lost this new code may raise some occasional exception because of some unhandled data access (nothing serious, but some fixes for those could be needed)