### PR TITLE
Refactor tests and increase coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ language: python
 python:
  - "3.7"
 before_install:
-    - pip install pytest pytest-cov
+    - pip install -r requirements-dev.txt
     - pip install coveralls
 install:
     - pip install -r requirements.txt
-    - pip install -r requirements-dev.txt
 # command to run tests
 script:
-    - py.test --cov=custom_components tests/ -vv -p no:warnings
+    - py.test --cov=custom_components tests/ -vv -s
 after_success:
     - coveralls
     - codecov

--- a/custom_components/huesensor/data_manager.py
+++ b/custom_components/huesensor/data_manager.py
@@ -48,8 +48,14 @@ class HueSensorData:
         self._update_listener = None
 
     async def _iter_data(self) -> AsyncIterable[Tuple[bool, str, str, dict]]:
-        for bridge in get_bridges(self.hass):
-            await bridge.sensor_manager.coordinator.async_request_refresh()
+        bridges = get_bridges(self.hass)
+        await asyncio.gather(
+            *[
+                bridge.sensor_manager.coordinator.async_request_refresh()
+                for bridge in bridges
+            ]
+        )
+        for bridge in bridges:
             data = parse_hue_api_response(
                 sensor.raw
                 for sensor in bridge.api.sensors.values()

--- a/custom_components/huesensor/data_manager.py
+++ b/custom_components/huesensor/data_manager.py
@@ -51,7 +51,8 @@ class HueSensorData:
         for bridge in get_bridges(self.hass):
             await bridge.sensor_manager.coordinator.async_request_refresh()
             data = parse_hue_api_response(
-                sensor.raw for sensor in bridge.api.sensors.values()
+                sensor.raw
+                for sensor in bridge.api.sensors.values()
                 if sensor.raw["modelid"].startswith(_KNOWN_MODEL_IDS)
             )
             for dev_id, dev_data in data.items():
@@ -98,7 +99,6 @@ class HueSensorData:
                 return
 
             if self._update_listener is not None:
-                _LOGGER.debug(f"Cancelling time tracker")
                 self._update_listener()
                 self._update_listener = None
 
@@ -166,10 +166,7 @@ class HueSensorBaseDevice(Entity):
         # )
         await self._data_manager.async_start_scheduler()
         _LOGGER.debug(
-            "%s: setup complete for %s:%s",
-            self.entity_id,
-            self.__class__.__name__,
-            self._hue_id,
+            "Setup complete for %s:%s", self.__class__.__name__, self._hue_id
         )
 
     async def async_will_remove_from_hass(self):

--- a/custom_components/huesensor/data_manager.py
+++ b/custom_components/huesensor/data_manager.py
@@ -28,7 +28,6 @@ def get_bridges(hass) -> List[HueBridge]:
 
 
 class HueSensorData:
-    """Get the latest sensor data."""
     """Sensor data handler for this custom integration."""
 
     def __init__(self, hass):
@@ -159,7 +158,8 @@ class HueSensorBaseDevice(Entity):
         # )
         await self._data_manager.async_start_scheduler()
         _LOGGER.debug(
-            "%s: setup complete for %s:%s", self.entity_id,
+            "%s: setup complete for %s:%s",
+            self.entity_id,
             self.__class__.__name__,
             self._hue_id,
         )

--- a/custom_components/huesensor/device_tracker.py
+++ b/custom_components/huesensor/device_tracker.py
@@ -1,13 +1,13 @@
-"""
-Device tracking with the Hue app.
-"""
+"""Device tracking with the Hue app."""
 import asyncio
 import logging
 from datetime import timedelta
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components import zone
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (  # noqa: F401
+    PLATFORM_SCHEMA,
+)
 from homeassistant.components.device_tracker.const import CONF_SCAN_INTERVAL
 from homeassistant.components.device_tracker.legacy import DeviceScanner
 from homeassistant.const import (
@@ -56,7 +56,9 @@ class HueDeviceScanner(DeviceScanner):
             "dev_id": slugify("hue_{}".format(sensor.name)),
             "host_name": sensor.name,
             "attributes": {
-                "last_updated": dt_util.as_local(dt_util.parse_datetime(last_updated)),
+                "last_updated": dt_util.as_local(
+                    dt_util.parse_datetime(last_updated)
+                ),
                 "unique_id": sensor.uniqueid,
             },
         }

--- a/custom_components/huesensor/hue_api_response.py
+++ b/custom_components/huesensor/hue_api_response.py
@@ -51,7 +51,10 @@ FOH_BUTTONS = {
     99: "double_lower_release",
 }
 RWL_RESPONSE_CODES = {
-    "0": "_click", "1": "_hold", "2": "_click_up", "3": "_hold_up"
+    "0": "_click",
+    "1": "_hold",
+    "2": "_click_up",
+    "3": "_hold_up",
 }
 TAP_BUTTONS = {34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click"}
 Z3_BUTTON = {
@@ -222,7 +225,9 @@ def _ident_raw_sensor(
     raw_sensor_data: Dict[str, Any]
 ) -> Tuple[Optional[str], Callable]:
     """Identify sensor types and return unique identifier and parser."""
-    def _default_parser(*x): return x
+
+    def _default_parser(*x):
+        return x
 
     model_id = raw_sensor_data["modelid"][0:3]
     unique_sensor_id = raw_sensor_data["uniqueid"]

--- a/custom_components/huesensor/remote.py
+++ b/custom_components/huesensor/remote.py
@@ -54,8 +54,7 @@ class HueRemote(HueSensorBaseDevice, RemoteDevice):
             icon = REMOTE_ICONS.get(data["model"])
             if icon:
                 return icon
-        _LOGGER.warning(f"No icon found for {self.entity_id}")
-        return "mdi:remote"
+        return "mdi:remote"  # pragma: no cover
 
     @property
     def force_update(self):

--- a/custom_components/huesensor/remote.py
+++ b/custom_components/huesensor/remote.py
@@ -2,7 +2,10 @@
 import logging
 
 from homeassistant.const import CONF_SCAN_INTERVAL
-from homeassistant.components.remote import PLATFORM_SCHEMA, RemoteDevice  # noqa: F401
+from homeassistant.components.remote import (  # noqa: F401
+    PLATFORM_SCHEMA,
+    RemoteDevice,
+)
 
 from . import DOMAIN
 from .data_manager import (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,10 @@
-asynctest
 black
-pytest
+pytest>=5.3
+pytest-aiohttp
+pytest-sugar
+pytest-timeout
+pytest==5.3.5
+requests_mock
 pytest-cov
 homeassistant==0.106.4
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,8 @@
 black
-pytest>=5.3
+pytest==5.3.5
 pytest-aiohttp
 pytest-sugar
 pytest-timeout
-pytest==5.3.5
 requests_mock
 pytest-cov
-homeassistant==0.106.4
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+asynctest
 black
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohue==2.0.0
-attrs==19.3.0
+homeassistant>=0.106.4
+aiohue>=2.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,82 @@
+"""Pytest fixtures for huesensors tests."""
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from aiohue import Bridge
+from aiohue.sensors import GenericSensor
+from homeassistant.core import HomeAssistant
+from homeassistant.components.hue import DOMAIN as HUE_DOMAIN, HueBridge
+from homeassistant.components.hue.sensor_base import SensorManager
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+import pytest
+
+from .sensor_samples import MOCK_ZGP, MOCK_ZLLPresence
+
+DEV_ID_REMOTE_1 = "ZGP_00:44:23:08"
+DEV_ID_SENSOR_1 = "SML_00:17:88:01:02:00:af:28-02"
+
+
+class MockBridgeUpdater:
+    """
+    Call counter for the hue data coordinator.
+
+    Used to mock and count bridge updates done with
+    `await bridge.sensor_manager.coordinator.async_request_refresh()`.
+    """
+
+    _counter: int = 0
+
+    def __await__(self):
+        """Dumb await."""
+        yield
+
+    def __call__(self, *args, **kwargs):
+        """Call just returns self, increasing counter."""
+        self._counter += 1
+        return self
+
+    @property
+    def call_count(self) -> int:
+        """Return call counter."""
+        return self._counter
+
+
+@pytest.fixture
+def mock_hass():
+    """Mock HA object for tests, including some sensors in hue integration."""
+    # mocking raw sensors (aiohue level)
+    rwl_sensor = MagicMock(spec=GenericSensor)
+    rwl_sensor.raw = deepcopy(MOCK_ZGP)
+
+    sml_sensor = MagicMock(spec=GenericSensor)
+    sml_sensor.raw = deepcopy(MOCK_ZLLPresence)
+
+    bridge = MagicMock(spec=Bridge)
+    bridge.sensors = {"rwl_1": rwl_sensor, "sml_1": sml_sensor}
+
+    # mocking HueBridge (homeassistant.components.hue level)
+    coordinator = MagicMock(spec=DataUpdateCoordinator)
+    coordinator.async_request_refresh = MockBridgeUpdater()
+
+    sensor_manager = MagicMock(spec=SensorManager)
+    sensor_manager.coordinator = coordinator
+
+    hue_bridge = MagicMock(spec=HueBridge)
+    hue_bridge.api = bridge
+    hue_bridge.sensor_manager = sensor_manager
+
+    # mocking homeassistant
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {HUE_DOMAIN: {0: hue_bridge}}
+    hass.config = MagicMock()
+    hass.states = MagicMock()
+
+    return hass
+
+
+def patch_async_track_time_interval():
+    """Mock hass.async_track_time_interval for tests."""
+    return patch(
+        "custom_components.huesensor.data_manager.async_track_time_interval",
+        autospec=True,
+    )

--- a/tests/sensor_samples.py
+++ b/tests/sensor_samples.py
@@ -182,3 +182,16 @@ PARSED_Z3_ROTARY = {
     "reachable": True,
     "last_updated": ["2020-01-31", "15:56:19"],
 }
+
+# Hue geofences
+MOCK_GEOFENCE = {
+    "state": {"presence": False, "lastupdated": "2019-04-09T06:05:00"},
+    "config": {"on": True, "reachable": True},
+    "name": "iPhone",
+    "type": "Geofence",
+    "modelid": "HA_GEOFENCE",
+    "manufacturername": "1ISn0hwg7oDVAmx4-gqDTN4eRR3ncfRl",
+    "swversion": "A_1",
+    "uniqueid": "L_02_iL4n7",
+    "recycle": False,
+}

--- a/tests/sensor_samples.py
+++ b/tests/sensor_samples.py
@@ -1,0 +1,184 @@
+"""Examples of raw and parsed data for known sensors."""
+
+# Binary sensors
+MOCK_ZLLPresence = {
+    "state": {"presence": False, "lastupdated": "2020-02-06T07:28:08"},
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
+    "config": {
+        "on": True,
+        "battery": 58,
+        "reachable": True,
+        "alert": "lselect",
+        "sensitivity": 2,
+        "sensitivitymax": 2,
+        "ledindication": False,
+        "usertest": False,
+        "pending": [],
+    },
+    "name": "Living room sensor",
+    "type": "ZLLPresence",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "productname": "Hue motion sensor",
+    "swversion": "6.1.1.27575",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0406",
+    "capabilities": {"certified": True, "primary": True},
+}
+MOCK_ZLLLightlevel = {
+    "state": {
+        "lightlevel": 0,
+        "dark": True,
+        "daylight": False,
+        "lastupdated": "2020-02-06T07:26:02",
+    },
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
+    "config": {
+        "on": True,
+        "battery": 58,
+        "reachable": True,
+        "alert": "none",
+        "tholddark": 16000,
+        "tholdoffset": 7000,
+        "ledindication": False,
+        "usertest": False,
+        "pending": [],
+    },
+    "name": "Hue ambient light sensor 1",
+    "type": "ZLLLightLevel",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "productname": "Hue ambient light sensor",
+    "swversion": "6.1.1.27575",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0400",
+    "capabilities": {"certified": True, "primary": False},
+}
+MOCK_ZLLTemperature = {
+    "state": {"temperature": 1744, "lastupdated": "2020-02-06T07:26:26"},
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
+    "config": {
+        "on": True,
+        "battery": 58,
+        "reachable": True,
+        "alert": "none",
+        "ledindication": False,
+        "usertest": False,
+        "pending": [],
+    },
+    "name": "Hue temperature sensor 1",
+    "type": "ZLLTemperature",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "productname": "Hue temperature sensor",
+    "swversion": "6.1.1.27575",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0402",
+    "capabilities": {"certified": True, "primary": False},
+}
+
+PARSED_ZLLPresence = {
+    "battery": 58,
+    "last_updated": ["2020-02-06", "07:28:08"],
+    "model": "SML",
+    "name": "Living room motion sensor",
+    "on": True,
+    "reachable": True,
+    "sensitivity": 2,
+    "state": "off",
+}
+PARSED_ZLLLightlevel = {
+    "dark": True,
+    "daylight": False,
+    "light_level": 0,
+    "lx": 1.0,
+    "threshold_dark": 16000,
+    "threshold_offset": 7000,
+}
+PARSED_ZLLTemperature = {"temperature": 17.44}
+
+# Remotes
+MOCK_ZGP = {
+    "state": {"buttonevent": 17, "lastupdated": "2019-06-22T14:43:50"},
+    "swupdate": {"state": "notupdatable", "lastinstall": None},
+    "config": {"on": True},
+    "name": "Hue Tap",
+    "type": "ZGPSwitch",
+    "modelid": "ZGPSWITCH",
+    "manufacturername": "Philips",
+    "productname": "Hue tap switch",
+    "diversityid": "d8cde5d5-0eef-4b95-b0f0-71ddd2952af4",
+    "uniqueid": "00:00:00:00:00:44:23:08-f2",
+    "capabilities": {"certified": True, "primary": True, "inputs": []},
+}
+MOCK_RWL = {
+    "state": {"buttonevent": 4002, "lastupdated": "2019-12-28T21:58:02"},
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-10-13T13:16:15"},
+    "config": {"on": True, "battery": 100, "reachable": True, "pending": []},
+    "name": "Hue dimmer switch 1",
+    "type": "ZLLSwitch",
+    "modelid": "RWL021",
+    "manufacturername": "Philips",
+    "productname": "Hue dimmer switch",
+    "diversityid": "73bbabea-3420-499a-9856-46bf437e119b",
+    "swversion": "6.1.1.28573",
+    "uniqueid": "00:17:88:01:10:3e:3a:dc-02-fc00",
+    "capabilities": {"certified": True, "primary": True, "inputs": []},
+}
+MOCK_Z3_ROTARY = {
+    "state": {
+        "rotaryevent": 2,
+        "expectedrotation": 208,
+        "expectedeventduration": 400,
+        "lastupdated": "2020-01-31T15:56:19",
+    },
+    "swupdate": {"state": "noupdates", "lastinstall": "2019-11-26T03:35:21"},
+    "config": {"on": True, "battery": 100, "reachable": True, "pending": []},
+    "name": "Lutron Aurora 1",
+    "type": "ZLLRelativeRotary",
+    "modelid": "Z3-1BRL",
+    "manufacturername": "Lutron",
+    "productname": "Lutron Aurora",
+    "diversityid": "2c3a75ff-55c4-4e4d-8c44-82d330b8eb9b",
+    "swversion": "3.4",
+    "uniqueid": "ff:ff:00:0f:e7:fd:ba:b7-01-fc00-0014",
+    "capabilities": {
+        "certified": True,
+        "primary": True,
+        "inputs": [
+            {
+                "repeatintervals": [400],
+                "events": [
+                    {"rotaryevent": 1, "eventtype": "start"},
+                    {"rotaryevent": 2, "eventtype": "repeat"},
+                ],
+            }
+        ],
+    },
+}
+
+PARSED_ZGP = {
+    "last_button_event": "3_click",
+    "last_updated": ["2019-06-22", "14:43:50"],
+    "model": "ZGP",
+    "name": "Hue Tap",
+    "state": "3_click",
+}
+PARSED_RWL = {
+    "battery": 100,
+    "last_button_event": "4_click_up",
+    "last_updated": ["2019-12-28", "21:58:02"],
+    "model": "RWL",
+    "name": "Hue dimmer switch 1",
+    "on": True,
+    "reachable": True,
+    "state": "4_click_up",
+}
+PARSED_Z3_ROTARY = {
+    "model": "Z3-",
+    "name": "Lutron Aurora 1",
+    "dial_state": "end",
+    "dial_position": 208,
+    "software_update": "noupdates",
+    "battery": 100,
+    "on": True,
+    "reachable": True,
+    "last_updated": ["2020-01-31", "15:56:19"],
+}

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,13 +1,25 @@
 """Tests for binary_sensor.py."""
 import logging
+from datetime import timedelta
 
 import pytest
 
+from custom_components.huesensor import DOMAIN
+from custom_components.huesensor.binary_sensor import (
+    async_setup_platform,
+    HueBinarySensor,
+)
+from custom_components.huesensor.data_manager import HueSensorData
 from custom_components.huesensor.hue_api_response import (
     parse_hue_api_response,
     parse_sml,
 )
 
+from .conftest import (
+    DEV_ID_REMOTE_1,
+    DEV_ID_SENSOR_1,
+    patch_async_track_time_interval,
+)
 from .sensor_samples import (
     MOCK_ZLLLightlevel,
     MOCK_ZLLPresence,
@@ -47,8 +59,44 @@ def test_parse_sensor_raw_data(
     """Test data parsers for known sensors."""
     assert parser_func(raw_response) == parsed_response
     with caplog.at_level(level=logging.WARNING):
-        assert (
-            parse_hue_api_response([raw_response]) 
-            == {sensor_key: parsed_response}
-        )
+        assert parse_hue_api_response([raw_response]) == {
+            sensor_key: parsed_response
+        }
         assert len(caplog.messages) == 0
+
+
+async def test_platform_binary_sensor_setup(mock_hass, caplog):
+    """Test platform setup for binary sensors."""
+    with caplog.at_level(logging.DEBUG):
+        with patch_async_track_time_interval():
+            await async_setup_platform(
+                mock_hass,
+                {
+                    "platform": "huesensor",
+                    "scan_interval": timedelta(seconds=2),
+                },
+                lambda *x: logging.warning("Added sensor entity: %s", x[0]),
+            )
+            assert DOMAIN in mock_hass.data
+            data_manager = mock_hass.data[DOMAIN]
+            assert isinstance(data_manager, HueSensorData)
+            assert data_manager._scan_interval == timedelta(seconds=2)
+            assert len(data_manager.data) == 2
+            assert DEV_ID_REMOTE_1 in data_manager.data
+            assert DEV_ID_SENSOR_1 in data_manager.data
+
+            assert len(data_manager.data) == 2
+            assert len(data_manager.sensors) == 1
+
+            assert DEV_ID_SENSOR_1 in data_manager.sensors
+            bin_sensor = data_manager.sensors[DEV_ID_SENSOR_1]
+            assert isinstance(bin_sensor, HueBinarySensor)
+            assert bin_sensor.device_class == "motion"
+            assert not bin_sensor.is_on
+            assert bin_sensor.state == "off"
+            assert not bin_sensor.should_poll
+            assert "light_level" in bin_sensor.device_state_attributes
+            assert bin_sensor.unique_id == DEV_ID_SENSOR_1
+
+            await bin_sensor.async_added_to_hass()
+            await bin_sensor.async_will_remove_from_hass()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -8,98 +8,14 @@ from custom_components.huesensor.hue_api_response import (
     parse_sml,
 )
 
-MOCK_ZLLPresence = {
-    "state": {"presence": False, "lastupdated": "2020-02-06T07:28:08"},
-    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
-    "config": {
-        "on": True,
-        "battery": 58,
-        "reachable": True,
-        "alert": "lselect",
-        "sensitivity": 2,
-        "sensitivitymax": 2,
-        "ledindication": False,
-        "usertest": False,
-        "pending": [],
-    },
-    "name": "Living room sensor",
-    "type": "ZLLPresence",
-    "modelid": "SML001",
-    "manufacturername": "Philips",
-    "productname": "Hue motion sensor",
-    "swversion": "6.1.1.27575",
-    "uniqueid": "00:17:88:01:02:00:af:28-02-0406",
-    "capabilities": {"certified": True, "primary": True},
-}
-MOCK_ZLLLightlevel = {
-    "state": {
-        "lightlevel": 0,
-        "dark": True,
-        "daylight": False,
-        "lastupdated": "2020-02-06T07:26:02",
-    },
-    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
-    "config": {
-        "on": True,
-        "battery": 58,
-        "reachable": True,
-        "alert": "none",
-        "tholddark": 16000,
-        "tholdoffset": 7000,
-        "ledindication": False,
-        "usertest": False,
-        "pending": [],
-    },
-    "name": "Hue ambient light sensor 1",
-    "type": "ZLLLightLevel",
-    "modelid": "SML001",
-    "manufacturername": "Philips",
-    "productname": "Hue ambient light sensor",
-    "swversion": "6.1.1.27575",
-    "uniqueid": "00:17:88:01:02:00:af:28-02-0400",
-    "capabilities": {"certified": True, "primary": False},
-}
-MOCK_ZLLTemperature = {
-    "state": {"temperature": 1744, "lastupdated": "2020-02-06T07:26:26"},
-    "swupdate": {"state": "noupdates", "lastinstall": "2019-05-06T13:14:45"},
-    "config": {
-        "on": True,
-        "battery": 58,
-        "reachable": True,
-        "alert": "none",
-        "ledindication": False,
-        "usertest": False,
-        "pending": [],
-    },
-    "name": "Hue temperature sensor 1",
-    "type": "ZLLTemperature",
-    "modelid": "SML001",
-    "manufacturername": "Philips",
-    "productname": "Hue temperature sensor",
-    "swversion": "6.1.1.27575",
-    "uniqueid": "00:17:88:01:02:00:af:28-02-0402",
-    "capabilities": {"certified": True, "primary": False},
-}
-
-PARSED_ZLLPresence = {
-    "battery": 58,
-    "last_updated": ["2020-02-06", "07:28:08"],
-    "model": "SML",
-    "name": "Living room motion sensor",
-    "on": True,
-    "reachable": True,
-    "sensitivity": 2,
-    "state": "off",
-}
-PARSED_ZLLLightlevel = {
-    "dark": True,
-    "daylight": False,
-    "light_level": 0,
-    "lx": 1.0,
-    "threshold_dark": 16000,
-    "threshold_offset": 7000,
-}
-PARSED_ZLLTemperature = {"temperature": 17.44}
+from .sensor_samples import (
+    MOCK_ZLLLightlevel,
+    MOCK_ZLLPresence,
+    MOCK_ZLLTemperature,
+    PARSED_ZLLLightlevel,
+    PARSED_ZLLPresence,
+    PARSED_ZLLTemperature,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,47 @@
+"""Tests for device_tracker.py."""
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from custom_components.huesensor.device_tracker import (
+    async_setup_scanner,
+    HueDeviceScanner,
+)
+
+from .conftest import MockAsyncCounter
+
+
+async def test_device_tracker_setup(mock_hass_2_bridges):
+    """Test platform setup for binary sensors."""
+    mock_async_see = MockAsyncCounter()
+    with patch(
+        "custom_components.huesensor.device_tracker.async_track_time_interval",
+        autospec=True,
+    ) as mock_track_time:
+        await async_setup_scanner(
+            mock_hass_2_bridges,
+            {"platform": "huesensor", "scan_interval": timedelta(seconds=10)},
+            mock_async_see,
+        )
+
+        assert mock_track_time.call_count == 1
+        assert mock_async_see.call_count == 1
+
+
+async def test_device_scanner(mock_hass, mock_hass_2_bridges):
+    """Test platform setup for binary sensors."""
+    mock_async_see = MockAsyncCounter()
+
+    # no sensors
+    empty_scanner = HueDeviceScanner(MagicMock(), mock_async_see)
+    await empty_scanner.async_update_info()
+    assert mock_async_see.call_count == 0
+
+    # sensors, but no geofence data
+    scanner = HueDeviceScanner(mock_hass, mock_async_see)
+    await scanner.async_update_info()
+    assert mock_async_see.call_count == 0
+
+    # 1 geofence in 2nd bridge
+    scanner = HueDeviceScanner(mock_hass_2_bridges, mock_async_see)
+    await scanner.async_update_info()
+    assert mock_async_see.call_count == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,9 +20,9 @@ from .conftest import (
 )
 
 
-async def test_integration(mock_hass_double_bridge, caplog):
+async def test_integration(mock_hass_2_bridges, caplog):
     """Test setup with yaml config for remotes and binary sensors."""
-    mock_hass = mock_hass_double_bridge
+    mock_hass = mock_hass_2_bridges
     entity_counter = []
     config_remote = {"platform": DOMAIN, "scan_interval": timedelta(seconds=3)}
     config_bs = {"platform": DOMAIN, "scan_interval": timedelta(seconds=2)}
@@ -84,11 +84,11 @@ async def test_integration(mock_hass_double_bridge, caplog):
             assert len(caplog.messages) == 7
 
             # Change the state on bridge and call update
-            hue_bridge = mock_hass.data[HUE_DOMAIN][0]
-            r1_data_st = hue_bridge.api.sensors["rwl_1"].raw["state"]
+            hue_bridge = mock_hass.data[HUE_DOMAIN][1]
+            r1_data_st = hue_bridge.api.sensors["ZGPSwitch_1_0"].raw["state"]
             r1_data_st["buttonevent"] = 16
             r1_data_st["lastupdated"] = "2019-06-22T14:43:55"
-            hue_bridge.api.sensors["rwl_1"].raw["state"] = r1_data_st
+            hue_bridge.api.sensors["ZGPSwitch_1_0"].raw["state"] = r1_data_st
 
             assert data_coord_b1.async_request_refresh.call_count == 2
             assert data_coord_b2.async_request_refresh.call_count == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,114 @@
+"""The huesensors tests."""
+import logging
+from datetime import timedelta
+
+from homeassistant.components.hue import DOMAIN as HUE_DOMAIN
+
+from custom_components.huesensor import DOMAIN
+from custom_components.huesensor.data_manager import HueSensorData
+from custom_components.huesensor.remote import (
+    async_setup_platform as async_setup_remote,
+)
+from custom_components.huesensor.binary_sensor import (
+    async_setup_platform as async_setup_binary_sensor,
+)
+
+from .conftest import (
+    DEV_ID_REMOTE_1,
+    DEV_ID_SENSOR_1,
+    patch_async_track_time_interval,
+)
+
+
+async def test_integration(mock_hass, caplog):
+    """Test setup with yaml config for remotes and binary sensors."""
+    entity_counter = []
+    config_remote = {"platform": DOMAIN, "scan_interval": timedelta(seconds=3)}
+    config_bs = {"platform": DOMAIN, "scan_interval": timedelta(seconds=2)}
+
+    def _add_entity_counter(*_args):
+        entity_counter.append(1)
+
+    with caplog.at_level(logging.DEBUG):
+        with patch_async_track_time_interval():
+            # setup remotes
+            await async_setup_remote(
+                mock_hass, config_remote, _add_entity_counter
+            )
+            assert sum(entity_counter) == 1
+
+            assert DOMAIN in mock_hass.data
+            data_manager = mock_hass.data[DOMAIN]
+            assert isinstance(data_manager, HueSensorData)
+            assert len(data_manager.data) == 2
+
+            # Check bridge updates
+            assert (
+                mock_hass.data[HUE_DOMAIN][
+                    0
+                ].sensor_manager.coordinator.async_request_refresh.call_count
+                == 1
+            )
+
+            assert len(data_manager.sensors) == 1
+            assert DEV_ID_REMOTE_1 in data_manager.sensors
+            remote = data_manager.sensors[DEV_ID_REMOTE_1]
+            assert remote.state == "3_click"
+            assert remote.icon == "mdi:remote"
+
+            # add to HA
+            await remote.async_added_to_hass()
+            remote.hass = mock_hass
+            remote.entity_id = "remote.test1"
+            assert len(caplog.messages) == 2
+
+            await async_setup_binary_sensor(
+                mock_hass, config_bs, _add_entity_counter
+            )
+            assert sum(entity_counter) == 2
+            assert len(data_manager.sensors) == 2
+
+            # Check bridge updates
+            assert (
+                mock_hass.data[HUE_DOMAIN][
+                    0
+                ].sensor_manager.coordinator.async_request_refresh.call_count
+                == 2
+            )
+            assert len(caplog.messages) == 4
+            assert DEV_ID_SENSOR_1 in data_manager.sensors
+            bin_sensor = data_manager.sensors[DEV_ID_SENSOR_1]
+
+            # add to HA
+            await bin_sensor.async_added_to_hass()
+            bin_sensor.hass = mock_hass
+            bin_sensor.entity_id = "binary_sensor.test1"
+            assert len(caplog.messages) == 5
+
+            # Change the state on bridge and call update
+            hue_bridge = mock_hass.data[HUE_DOMAIN][0]
+            r1_data_st = hue_bridge.api.sensors["rwl_1"].raw["state"]
+            r1_data_st["buttonevent"] = 16
+            r1_data_st["lastupdated"] = "2019-06-22T14:43:55"
+            hue_bridge.api.sensors["rwl_1"].raw["state"] = r1_data_st
+
+            await data_manager.async_update_from_bridges()
+            assert remote.state == "2_click"
+            assert len(caplog.messages) == 6
+
+            # Test scheduler: extra calls do nothing
+            await data_manager.async_start_scheduler()
+            # Test scheduler: forced re-schedule cancels current listener
+            data_manager.available = False
+            await data_manager.async_start_scheduler()
+            assert len(caplog.messages) == 7
+
+            # Remove entities from hass
+            await bin_sensor.async_will_remove_from_hass()
+            await remote.async_will_remove_from_hass()
+            assert len(caplog.messages) == 10
+
+            # Test scheduler: extra stops do nothing
+            await data_manager.async_stop_scheduler()
+
+        assert len(caplog.messages) == 11

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -10,93 +10,14 @@ from custom_components.huesensor.hue_api_response import (
     parse_z3_rotary,
 )
 
-MOCK_ZGP = {
-    "state": {"buttonevent": 17, "lastupdated": "2019-06-22T14:43:50"},
-    "swupdate": {"state": "notupdatable", "lastinstall": None},
-    "config": {"on": True},
-    "name": "Hue Tap",
-    "type": "ZGPSwitch",
-    "modelid": "ZGPSWITCH",
-    "manufacturername": "Philips",
-    "productname": "Hue tap switch",
-    "diversityid": "d8cde5d5-0eef-4b95-b0f0-71ddd2952af4",
-    "uniqueid": "00:00:00:00:00:44:23:08-f2",
-    "capabilities": {"certified": True, "primary": True, "inputs": []},
-}
-MOCK_RWL = {
-    "state": {"buttonevent": 4002, "lastupdated": "2019-12-28T21:58:02"},
-    "swupdate": {"state": "noupdates", "lastinstall": "2019-10-13T13:16:15"},
-    "config": {"on": True, "battery": 100, "reachable": True, "pending": []},
-    "name": "Hue dimmer switch 1",
-    "type": "ZLLSwitch",
-    "modelid": "RWL021",
-    "manufacturername": "Philips",
-    "productname": "Hue dimmer switch",
-    "diversityid": "73bbabea-3420-499a-9856-46bf437e119b",
-    "swversion": "6.1.1.28573",
-    "uniqueid": "00:17:88:01:10:3e:3a:dc-02-fc00",
-    "capabilities": {"certified": True, "primary": True, "inputs": []},
-}
-MOCK_Z3_ROTARY = {
-    "state": {
-        "rotaryevent": 2,
-        "expectedrotation": 208,
-        "expectedeventduration": 400,
-        "lastupdated": "2020-01-31T15:56:19",
-    },
-    "swupdate": {"state": "noupdates", "lastinstall": "2019-11-26T03:35:21"},
-    "config": {"on": True, "battery": 100, "reachable": True, "pending": []},
-    "name": "Lutron Aurora 1",
-    "type": "ZLLRelativeRotary",
-    "modelid": "Z3-1BRL",
-    "manufacturername": "Lutron",
-    "productname": "Lutron Aurora",
-    "diversityid": "2c3a75ff-55c4-4e4d-8c44-82d330b8eb9b",
-    "swversion": "3.4",
-    "uniqueid": "ff:ff:00:0f:e7:fd:ba:b7-01-fc00-0014",
-    "capabilities": {
-        "certified": True,
-        "primary": True,
-        "inputs": [
-            {
-                "repeatintervals": [400],
-                "events": [
-                    {"rotaryevent": 1, "eventtype": "start"},
-                    {"rotaryevent": 2, "eventtype": "repeat"},
-                ],
-            }
-        ],
-    },
-}
-
-PARSED_ZGP = {
-    "last_button_event": "3_click",
-    "last_updated": ["2019-06-22", "14:43:50"],
-    "model": "ZGP",
-    "name": "Hue Tap",
-    "state": "3_click",
-}
-PARSED_RWL = {
-    "battery": 100,
-    "last_button_event": "4_click_up",
-    "last_updated": ["2019-12-28", "21:58:02"],
-    "model": "RWL",
-    "name": "Hue dimmer switch 1",
-    "on": True,
-    "reachable": True,
-    "state": "4_click_up",
-}
-PARSED_Z3_ROTARY = {
-    "model": "Z3-",
-    "name": "Lutron Aurora 1",
-    "dial_state": "end",
-    "dial_position": 208,
-    "software_update": "noupdates",
-    "battery": 100,
-    "on": True,
-    "reachable": True,
-    "last_updated": ["2020-01-31", "15:56:19"],
-}
+from .sensor_samples import (
+    MOCK_RWL, 
+    MOCK_ZGP,
+    MOCK_Z3_ROTARY,
+    PARSED_RWL,
+    PARSED_ZGP,
+    PARSED_Z3_ROTARY,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,5 +1,10 @@
 """Tests for remote.py."""
+import logging
+
+import pytest
+
 from custom_components.huesensor.hue_api_response import (
+    parse_hue_api_response,
     parse_rwl,
     parse_zgp,
     parse_z3_rotary,
@@ -94,7 +99,27 @@ PARSED_Z3_ROTARY = {
 }
 
 
-def test_parse_zgp():
-    assert parse_zgp(MOCK_ZGP) == PARSED_ZGP
-    assert parse_rwl(MOCK_RWL) == PARSED_RWL
-    assert parse_z3_rotary(MOCK_Z3_ROTARY) == PARSED_Z3_ROTARY
+@pytest.mark.parametrize(
+    "raw_response, sensor_key, parsed_response, parser_func",
+    (
+        (MOCK_ZGP, "ZGP_00:44:23:08", PARSED_ZGP, parse_zgp),
+        (MOCK_RWL, "RWL_00:17:88:01:10:3e:3a:dc-02", PARSED_RWL, parse_rwl),
+        (
+            MOCK_Z3_ROTARY,
+            "Z3-_ff:ff:00:0f:e7:fd:ba:b7-01-fc00",
+            PARSED_Z3_ROTARY,
+            parse_z3_rotary,
+        ),
+    ),
+)
+def test_parse_remote_raw_data(
+    raw_response, sensor_key, parsed_response, parser_func, caplog
+):
+    """Test data parsers for known remotes and check behavior for unknown."""
+    assert parser_func(raw_response) == parsed_response
+    unknown_sensor_data = {"modelid": "new_one", "uniqueid": "ff:00:11:22"}
+    with caplog.at_level(level=logging.WARNING):
+        assert parse_hue_api_response(
+            [raw_response, unknown_sensor_data, raw_response]
+        ) == {sensor_key: parsed_response}
+        assert len(caplog.messages) == 1

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,17 +1,26 @@
 """Tests for remote.py."""
 import logging
+from datetime import timedelta
 
 import pytest
 
+from custom_components.huesensor import DOMAIN
+from custom_components.huesensor.data_manager import HueSensorData
 from custom_components.huesensor.hue_api_response import (
     parse_hue_api_response,
     parse_rwl,
     parse_zgp,
     parse_z3_rotary,
 )
+from custom_components.huesensor.remote import async_setup_platform, HueRemote
 
+from .conftest import (
+    DEV_ID_REMOTE_1,
+    DEV_ID_SENSOR_1,
+    patch_async_track_time_interval,
+)
 from .sensor_samples import (
-    MOCK_RWL, 
+    MOCK_RWL,
     MOCK_ZGP,
     MOCK_Z3_ROTARY,
     PARSED_RWL,
@@ -39,8 +48,43 @@ def test_parse_remote_raw_data(
     """Test data parsers for known remotes and check behavior for unknown."""
     assert parser_func(raw_response) == parsed_response
     unknown_sensor_data = {"modelid": "new_one", "uniqueid": "ff:00:11:22"}
-    with caplog.at_level(level=logging.WARNING):
-        assert parse_hue_api_response(
-            [raw_response, unknown_sensor_data, raw_response]
-        ) == {sensor_key: parsed_response}
-        assert len(caplog.messages) == 1
+    assert parse_hue_api_response(
+        [raw_response, unknown_sensor_data, raw_response]
+    ) == {sensor_key: parsed_response}
+    assert len(caplog.messages) == 0
+
+
+async def test_platform_remote_setup(mock_hass, caplog):
+    """Test platform setup for remotes."""
+    with caplog.at_level(logging.DEBUG):
+        with patch_async_track_time_interval():
+            await async_setup_platform(
+                mock_hass,
+                {
+                    "platform": "huesensor",
+                    "scan_interval": timedelta(seconds=3),
+                },
+                lambda *x: logging.warning("Added remote entity: %s", x[0]),
+            )
+
+            assert DOMAIN in mock_hass.data
+            data_manager = mock_hass.data[DOMAIN]
+            assert isinstance(data_manager, HueSensorData)
+            assert data_manager._scan_interval == timedelta(seconds=3)
+            assert len(data_manager.data) == 2
+            assert DEV_ID_REMOTE_1 in data_manager.data
+            assert DEV_ID_SENSOR_1 in data_manager.data
+
+            assert len(data_manager.sensors) == 1
+            assert DEV_ID_REMOTE_1 in data_manager.sensors
+            remote = data_manager.sensors[DEV_ID_REMOTE_1]
+            assert isinstance(remote, HueRemote)
+            assert remote.force_update
+            assert remote.state == "3_click"
+            assert remote.icon == "mdi:remote"
+            assert not remote.should_poll
+            assert "last_updated" in remote.device_state_attributes
+            assert remote.unique_id == DEV_ID_REMOTE_1
+
+            await remote.async_added_to_hass()
+            await remote.async_will_remove_from_hass()


### PR DESCRIPTION
cc @robmarkcole 

closes #204 

### Description

Continue to refactor work (following #223), this time reworking the test suite to cover not just the parsing logic but also the HA config setup and the `data_manager` access.

### Changes

- Now all examples for raw sensor data and parsed data live in `tests/sensor_samples.py`
- Applied `black` with 79 chars (I could change)
- Coverage for `remote` and `binary_sensor` is almost complete, `device_tracker` remains untouched.

## TODO

- [x] Test multiple bridges to try fixing #225