### PR TITLE
Fix setup flow broken with last refactor

### DIFF
--- a/custom_components/huesensor/hue_api_response.py
+++ b/custom_components/huesensor/hue_api_response.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, Iterable, Dict, Optional, Tuple
 
 from homeassistant.const import STATE_OFF, STATE_ON
 
-REMOTE_MODELS = ["RWL", "ROM", "FOH", "ZGP", "Z3-"]
-BINARY_SENSOR_MODELS = ["SML"]
+REMOTE_MODELS = ("RWL", "ROM", "FOH", "ZGP", "Z3-")
+BINARY_SENSOR_MODELS = ("SML",)
 ENTITY_ATTRS = {
     "RWL": ["last_updated", "last_button_event", "battery", "on", "reachable"],
     "ROM": ["last_updated", "last_button_event", "battery", "on", "reachable"],


### PR DESCRIPTION
#### Description

With last changes, a detected new device in any bridge was not added (only those available in platform setup were included), and errors were raising for some people.

* Now we register 'model types' in setup platform, and add to HA the entities that match, for each platform.
* If an unregistered device (of a registered model) appears at any time, it is also added to HA (like before the refactor).
* If some registered entity is caught in a data update before being added to HA, a warning is logged, **avoiding the KeyError stated in #224 and #228** (I hope)

Also, there is a slightly better async access for multiple Hue bridges, which **could fix #225 **

If not, then I suppose the next step would be to split the scheduling for each bridge**, covering the case that some bridges could be _lazier_ than the others.

** Note1: Right now we use 1 update schedule, for all remotes, sensors and bridges. The way it works is that, when each update is finished, a new one is programmed. _**But**_ if one of the bridges is timing out, it would be delaying the others, as the unfinished call to it is avoiding new updates for the others.
If that is the case, it can be fixed easily by handling different schedules for each bridge.

