### PR TITLE
suggest icon change

### DIFF
--- a/custom_components/huesensor/remote.py
+++ b/custom_components/huesensor/remote.py
@@ -18,9 +18,9 @@ from .hue_api_response import REMOTE_MODELS
 _LOGGER = logging.getLogger(__name__)
 
 REMOTE_ICONS = {
-    "RWL": "mdi:remote",
+    "RWL": "mdi:light-switch",
     "ROM": "mdi:remote",
-    "ZGP": "mdi:remote",
+    "ZGP": "mdi:google-circles-communities",
     "FOH": "mdi:light-switch",
     "Z3-": "mdi:light-switch",
 }


### PR DESCRIPTION
for  RWL and ZGP, which resemble the real life hardware switches rather nicely.
Since this might move to a core HA integration, thought it best to take my chance now ;-)
<img width="497" alt="Schermafbeelding 2020-03-12 om 17 27 25" src="https://user-images.githubusercontent.com/33354141/76543405-c3b47400-6486-11ea-81eb-82fa4dffe41d.png">

also feel we should go back to the 'official' states for the click/tap remotes, but will do so in the appropriate file
