### PR TITLE
Suggest to change button event names

### DIFF
--- a/custom_components/huesensor/hue_api_response.py
+++ b/custom_components/huesensor/hue_api_response.py
@@ -51,12 +51,12 @@ FOH_BUTTONS = {
     99: "double_lower_release",
 }
 RWL_RESPONSE_CODES = {
-    "0": "_click",
-    "1": "_hold",
-    "2": "_click_up",
-    "3": "_hold_up",
+    "0": " click",
+    "1": " hold",
+    "2": " click release",
+    "3": " hold release",
 }
-TAP_BUTTONS = {34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click"}
+TAP_BUTTONS = {34: "1", 16: "2", 17: "3", 18: "4"}
 Z3_BUTTON = {
     1000: "initial_press",
     1001: "repeat",


### PR DESCRIPTION
to go back to official Hue Api names, to get it as close as possible to HA core acceptance.

for Tap switch, left out _click, since there is no other type of click available, and the only info of interest is the button number
<img width="488" alt="Schermafbeelding 2020-03-12 om 17 34 04" src="https://user-images.githubusercontent.com/33354141/76544098-c1064e80-6487-11ea-83ac-516dd0c863c1.png">
